### PR TITLE
Sector timing rework

### DIFF
--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -2035,7 +2035,7 @@ namespace CrewChiefV4.assetto
                     opponentData.IsNewLap = true;
                     // recheck the car class here?
                 }
-                else if (opponentData.CurrentSectorNumber == 1 && sector == 2 || opponentData.CurrentSectorNumber == 2 && sector == 3)
+                else if ((opponentData.CurrentSectorNumber == 1 && sector == 2) || (opponentData.CurrentSectorNumber == 2 && sector == 3))
                 {
                     opponentData.AddCumulativeSectorData(opponentData.CurrentSectorNumber, racePosition, completedLapTime, sessionRunningTime,
                         lapIsValid && validSpeed, false, trackTempreture, airTemperature);

--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -128,7 +128,7 @@ namespace CrewChiefV4.assetto
             playerLapData.Add(thisLapData);
         }
 
-        public float addPlayerLapdata(int sectorNumber, float cumulativeSectorTime, float gameTimeAtSectorEnd)
+        public float addPlayerLapdata(int sectorNumber, float cumulativeSectorTime, float gameTimeAtSectorEnd, int position)
         {
             LapData lapData = playerLapData[playerLapData.Count - 1];
             if (cumulativeSectorTime <= 0)
@@ -149,6 +149,7 @@ namespace CrewChiefV4.assetto
                 thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[1] - lapData.SectorTimes[0];
             }
             lapData.SectorTimes[sectorNumber - 1] = thisSectorTime;
+            lapData.SectorPositions[sectorNumber - 1] = position;
             lapData.GameTimeAtSectorEnd.Add(gameTimeAtSectorEnd);
 
             return thisSectorTime;
@@ -1300,7 +1301,7 @@ namespace CrewChiefV4.assetto
                         sectorTimeToUse = currentGameState.SessionData.LapTimeCurrent;
                     }
 
-                    sectorTimeToUse = addPlayerLapdata(previousGameState.SessionData.SectorNumber, sectorTimeToUse, currentGameState.SessionData.SessionRunningTime);
+                    sectorTimeToUse = addPlayerLapdata(previousGameState.SessionData.SectorNumber, sectorTimeToUse, currentGameState.SessionData.SessionRunningTime, currentGameState.SessionData.Position);
 
                     if (currentGameState.SessionData.SectorNumber == 1 && shared.acsGraphic.numberOfLaps > 0)
                     {

--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -128,21 +128,27 @@ namespace CrewChiefV4.assetto
             playerLapData.Add(thisLapData);
         }
 
-        public float addPlayerLapdata(float cumulativeSectorTime, float gameTimeAtSectorEnd)
+        public float addPlayerLapdata(int sectorNumber, float cumulativeSectorTime, float gameTimeAtSectorEnd)
         {
             LapData lapData = playerLapData[playerLapData.Count - 1];
             if (cumulativeSectorTime <= 0)
             {
                 cumulativeSectorTime = gameTimeAtSectorEnd - lapData.GameTimeAtLapStart;
             }
-            float thisSectorTime = cumulativeSectorTime;
-            int sectorNumber = 1;
-            foreach (float sectorTime in lapData.SectorTimes)
+            float thisSectorTime = 0; ;
+            if (sectorNumber == 1)
             {
-                sectorNumber++;
-                thisSectorTime = thisSectorTime - sectorTime;
+                thisSectorTime = cumulativeSectorTime;
             }
-            lapData.SectorTimes.Add(thisSectorTime);
+            else if (sectorNumber == 2)
+            {
+                thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[0];
+            }
+            else if (sectorNumber == 3)
+            {
+                thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[1] - lapData.SectorTimes[0];
+            }
+            lapData.SectorTimes[sectorNumber - 1] = thisSectorTime;
             lapData.GameTimeAtSectorEnd.Add(gameTimeAtSectorEnd);
 
             return thisSectorTime;
@@ -1294,7 +1300,7 @@ namespace CrewChiefV4.assetto
                         sectorTimeToUse = currentGameState.SessionData.LapTimeCurrent;
                     }
 
-                    sectorTimeToUse = addPlayerLapdata(sectorTimeToUse, currentGameState.SessionData.SessionRunningTime);
+                    sectorTimeToUse = addPlayerLapdata(previousGameState.SessionData.SectorNumber, sectorTimeToUse, currentGameState.SessionData.SessionRunningTime);
 
                     if (currentGameState.SessionData.SectorNumber == 1 && shared.acsGraphic.numberOfLaps > 0)
                     {
@@ -1503,7 +1509,7 @@ namespace CrewChiefV4.assetto
                                         int opponentPositionAtLastSector = currentOpponentData.Position;
                                         LapData currentLapData = currentOpponentData.getCurrentLapData();
 
-                                        if (currentLapData != null && currentLapData.SectorPositions.Count > numberOfSectorsOnTrack - 1)
+                                        if (currentLapData != null)
                                         {
                                             opponentPositionAtLastSector = currentLapData.SectorPositions[numberOfSectorsOnTrack];
                                         }
@@ -2031,7 +2037,8 @@ namespace CrewChiefV4.assetto
                 }
                 else if (opponentData.CurrentSectorNumber == 1 && sector == 2 || opponentData.CurrentSectorNumber == 2 && sector == 3)
                 {
-                    opponentData.AddCumulativeSectorData(racePosition, completedLapTime, sessionRunningTime, lapIsValid && validSpeed, false, trackTempreture, airTemperature);
+                    opponentData.AddCumulativeSectorData(opponentData.CurrentSectorNumber, racePosition, completedLapTime, sessionRunningTime,
+                        lapIsValid && validSpeed, false, trackTempreture, airTemperature);
                 }
                 opponentData.CurrentSectorNumber = sector;
             }

--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -1341,7 +1341,6 @@ namespace CrewChiefV4.assetto
                             {
                                 currentGameState.SessionData.PlayerBestLapSector1Time = currentGameState.SessionData.LastSector1Time;
                                 currentGameState.SessionData.PlayerBestLapSector2Time = currentGameState.SessionData.LastSector2Time;
-                                currentGameState.SessionData.PlayerBestLapSector3Time = currentGameState.SessionData.LastSector3Time;
                             }
 
                         }
@@ -2028,7 +2027,7 @@ namespace CrewChiefV4.assetto
                     if (opponentData.OpponentLapData.Count > 0)
                     {
                         opponentData.CompleteLapWithProvidedLapTime(leaderBoardPosition, sessionRunningTime, lastLapTime,
-                            lapIsValid && validSpeed, false, trackTempreture, airTemperature, sessionLengthIsTime, sessionTimeRemaining);
+                            lapIsValid && validSpeed, false, trackTempreture, airTemperature, sessionLengthIsTime, sessionTimeRemaining, trackNumberOfSectors);
                     }
 
                     opponentData.StartNewLap(completedLaps + 1, leaderBoardPosition, isInPits, sessionRunningTime, false, trackTempreture, airTemperature);

--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -128,7 +128,7 @@ namespace CrewChiefV4.assetto
             playerLapData.Add(thisLapData);
         }
 
-        public float addPlayerLapdata(int sectorNumber, float cumulativeSectorTime, float gameTimeAtSectorEnd, int position)
+        public float addPlayerLapdata(int sectorNumberJustCompleted, float cumulativeSectorTime, float gameTimeAtSectorEnd, int position)
         {
             LapData lapData = playerLapData[playerLapData.Count - 1];
             if (cumulativeSectorTime <= 0)
@@ -136,21 +136,21 @@ namespace CrewChiefV4.assetto
                 cumulativeSectorTime = gameTimeAtSectorEnd - lapData.GameTimeAtLapStart;
             }
             float thisSectorTime = 0; ;
-            if (sectorNumber == 1)
+            if (sectorNumberJustCompleted == 1)
             {
                 thisSectorTime = cumulativeSectorTime;
             }
-            else if (sectorNumber == 2)
+            else if (sectorNumberJustCompleted == 2)
             {
                 thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[0];
             }
-            else if (sectorNumber == 3)
+            else if (sectorNumberJustCompleted == 3)
             {
                 thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[1] - lapData.SectorTimes[0];
             }
-            lapData.SectorTimes[sectorNumber - 1] = thisSectorTime;
-            lapData.SectorPositions[sectorNumber - 1] = position;
-            lapData.GameTimeAtSectorEnd.Add(gameTimeAtSectorEnd);
+            lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
+            lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
+            lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
 
             return thisSectorTime;
         }

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -649,7 +649,7 @@ namespace CrewChiefV4.GameState
                     float estimatedLapTime = lapData.SectorTimes.Sum();
                     LastLapValid = lapData.IsValid;
                     // pcars-specific sanity checks
-                    if (lapData.SectorTimes[0] > worldRecordS1Time - 0.1 && lapData.SectorTimes[1] > worldRecordS2Time - 0.1 && lapData.SectorTimes[2] > worldRecordS2Time - 0.1 &&
+                    if (lapData.SectorTimes[0] > worldRecordS1Time - 0.1 && lapData.SectorTimes[1] > worldRecordS2Time - 0.1 && lapData.SectorTimes[2] > worldRecordS3Time - 0.1 &&
                         estimatedLapTime > worldRecordLapTime - 0.1 && estimatedLapTime > 0)
                     {
                         lapData.LapTime = estimatedLapTime;

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -330,14 +330,14 @@ namespace CrewChiefV4.GameState
         }
 
         public void playerCompleteLapWithProvidedLapTime(int position, float gameTimeAtLapEnd, float providedLapTime,
-            Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining)
+            Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining, int numberOfSectors)
         {
             if (PlayerLapData.Count > 0)
             {
                 LapData lapData = PlayerLapData[PlayerLapData.Count - 1];
                 if (PlayerLapData.Count == 1 || !lapData.hasMissingSectors)
                 {
-                    playerAddCumulativeSectorData(3, position, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
+                    playerAddCumulativeSectorData(numberOfSectors, position, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
                     lapData.LapTime = providedLapTime;
 
                     LapTimePrevious = providedLapTime;
@@ -632,6 +632,7 @@ namespace CrewChiefV4.GameState
         public void CompleteLapWithEstimatedLapTime(int position, float gameTimeAtLapEnd, float worldRecordLapTime, float worldRecordS1Time, float worldRecordS2Time, float worldRecordS3Time,
             Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining)
         {
+            // only used by PCars where all tracks have 3 sectors
             AddCumulativeSectorData(3, position, -1, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
             if (OpponentLapData.Count > 0)
             {
@@ -670,9 +671,9 @@ namespace CrewChiefV4.GameState
         }
 
         public void CompleteLapWithLastSectorTime(int position, float lastSectorTime, float gameTimeAtLapEnd,
-            Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining)
+            Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining, int numberOfSectors)
         {
-            AddSectorData(3, position, lastSectorTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
+            AddSectorData(numberOfSectors, position, lastSectorTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
             if (OpponentLapData.Count > 0)
             {
                 LapData lapData = OpponentLapData[OpponentLapData.Count - 1];
@@ -709,13 +710,13 @@ namespace CrewChiefV4.GameState
         }
 
         public void CompleteLapWithProvidedLapTime(int position, float gameTimeAtLapEnd, float providedLapTime,
-            Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining)
+            Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining, int numberOfSectors)
         {
             if (OpponentLapData.Count > 0)
             {                
                 LapData lapData = OpponentLapData[OpponentLapData.Count - 1];
                 if (OpponentLapData.Count == 1 || !lapData.hasMissingSectors) {
-                    AddCumulativeSectorData(3, position, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
+                    AddCumulativeSectorData(numberOfSectors, position, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
                     lapData.LapTime = providedLapTime;
                     LastLapTime = providedLapTime;
                     if (lapData.IsValid && (CurrentBestLapTime == -1 || CurrentBestLapTime > lapData.LapTime))

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -406,7 +406,7 @@ namespace CrewChiefV4.GameState
                 }
                 lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
                 lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
-                lapData.GameTimeAtSectorEnd.Add(gameTimeAtSectorEnd);
+                lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
                 if (lapData.IsValid && !lapIsValid)
                 {
                     lapData.IsValid = false;
@@ -784,7 +784,7 @@ namespace CrewChiefV4.GameState
                 }
                 lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
                 lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
-                lapData.GameTimeAtSectorEnd.Add(gameTimeAtSectorEnd);
+                lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
                 if (lapData.IsValid && !lapIsValid)
                 {
                     lapData.IsValid = false;
@@ -820,7 +820,7 @@ namespace CrewChiefV4.GameState
                 }
                 lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
                 lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
-                lapData.GameTimeAtSectorEnd.Add(gameTimeAtSectorEnd);
+                lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
                 if (lapData.IsValid && !lapIsValid)
                 {
                     lapData.IsValid = false;

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -810,6 +810,9 @@ namespace CrewChiefV4.GameState
             {
                 LapData lapData = OpponentLapData[OpponentLapData.Count - 1];
                 lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
+
+                // fragile code here. If the lap is invalid PCars network mode sends -1 (-123 actually but never mind). If the data is just missing (we had no sectorX time info) 
+                // then we'll have 0. So looking for sectorTime[x] == 0 is different from looking for -1
                 if ((sectorNumberJustCompleted == 2 && lapData.SectorTimes[0] == 0) || (sectorNumberJustCompleted == 3 && lapData.SectorTimes[1] == 0))
                 {
                     lapData.hasMissingSectors = true;

--- a/CrewChiefV4/PCars/PCarsGameStateMapper.cs
+++ b/CrewChiefV4/PCars/PCarsGameStateMapper.cs
@@ -697,8 +697,9 @@ namespace CrewChiefV4.PCars
                     }
                     CarData.CarClass opponentCarClass = !shared.hasOpponentClassData || shared.isSameClassAsPlayer[i] ? currentGameState.carClass : CarData.DEFAULT_PCARS_OPPONENT_CLASS;
                     String participantName = StructHelper.getNameFromBytes(participantStruct.mName).ToLower();
-
-                    if (participantName != null && participantName.Length > 0)
+                    // awesomely, the driver can appear twice (or more?) in the array. Can't be sure which of the copies is the dead one so assume the first is the one to use.
+                    // This may be wrong but the PCars data is such a fucking shambles I honestly can't be arsed with it any more.
+                    if (participantName != null && participantName.Length > 0 && !namesInRawData.Contains(participantName))
                     {
                         namesInRawData.Add(participantName);
                         OpponentData currentOpponentData = getOpponentForName(currentGameState, participantName);

--- a/CrewChiefV4/PCars/PCarsGameStateMapper.cs
+++ b/CrewChiefV4/PCars/PCarsGameStateMapper.cs
@@ -1249,7 +1249,7 @@ namespace CrewChiefV4.PCars
                                 lapInvalidated = true;
                             }
                             opponentData.CompleteLapWithLastSectorTime(racePosition, lastSectorTime, sessionRunningTime, 
-                                !lapInvalidated, isRaining, trackTemp, airTemp, sessionLengthIsTime, sessionTimeRemaining);
+                                !lapInvalidated, isRaining, trackTemp, airTemp, sessionLengthIsTime, sessionTimeRemaining, 3);
                         }
                         else
                         {

--- a/CrewChiefV4/PCars/PCarsGameStateMapper.cs
+++ b/CrewChiefV4/PCars/PCarsGameStateMapper.cs
@@ -1272,12 +1272,12 @@ namespace CrewChiefV4.PCars
                             lastSectorTime = -1;
                             lapInvalidated = true;
                         }
-                        opponentData.AddSectorData(racePosition, lastSectorTime, sessionRunningTime, !lapInvalidated, isRaining, trackTemp, airTemp);
+                        opponentData.AddSectorData(opponentData.CurrentSectorNumber, racePosition, lastSectorTime, sessionRunningTime, !lapInvalidated, isRaining, trackTemp, airTemp);
                     }
                     else
                     {
                         // use the inbuilt timing
-                        opponentData.AddCumulativeSectorData(racePosition, -1, sessionRunningTime, !lapInvalidated, isRaining, trackTemp, airTemp);
+                        opponentData.AddCumulativeSectorData(opponentData.CurrentSectorNumber, racePosition, -1, sessionRunningTime, !lapInvalidated, isRaining, trackTemp, airTemp);
                     }
                 }
                 opponentData.CurrentSectorNumber = sector;

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -723,7 +723,7 @@ namespace CrewChiefV4.RaceRoom
                             {
                                 int opponentPositionAtSector3 = currentOpponentData.Position;
                                 LapData currentLapData = currentOpponentData.getCurrentLapData();
-                                if (currentLapData != null && currentLapData.SectorPositions.Count > 2)
+                                if (currentLapData != null)
                                 {
                                     opponentPositionAtSector3 = currentLapData.SectorPositions[2];
                                 }
@@ -1446,7 +1446,7 @@ namespace CrewChiefV4.RaceRoom
                 }
                 else if (opponentData.CurrentSectorNumber == 1 && sector == 2 || opponentData.CurrentSectorNumber == 2 && sector == 3)
                 {
-                    opponentData.AddCumulativeSectorData(racePosition, sectorTime, sessionRunningTime, lapIsValid && validSpeed, false, 20, 20);
+                    opponentData.AddCumulativeSectorData(opponentData.CurrentSectorNumber, racePosition, sectorTime, sessionRunningTime, lapIsValid && validSpeed, false, 20, 20);
                     if (sector == 2)
                     {
                         // crappy but necessary assumption - assume single class here. It only really matters for DTM races, which will be a single class.

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -1439,7 +1439,7 @@ namespace CrewChiefV4.RaceRoom
                     if (opponentData.OpponentLapData.Count > 0)
                     {
                         opponentData.CompleteLapWithProvidedLapTime(racePosition, sessionRunningTime, completedLapTime,
-                            lapIsValid && validSpeed, false, 20, 20, sessionLengthIsTime, sessionTimeRemaining);
+                            lapIsValid && validSpeed, false, 20, 20, sessionLengthIsTime, sessionTimeRemaining, 3);
                     }
                     opponentData.StartNewLap(completedLaps + 1, racePosition, isInPits, sessionRunningTime, false, 20, 20);
                     opponentData.IsNewLap = true;

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -1438,32 +1438,8 @@ namespace CrewChiefV4.RaceRoom
                 {
                     if (opponentData.OpponentLapData.Count > 0)
                     {
-                        // Pay attention...
-                        // raceroom doesn't clear the participantStruct.SectorTimePreviousSelf.Sector value when a driver quits to pit.
-                        // This means that, when he exits the pits and comes round to start another flying lap, the participantStruct.SectorTimePreviousSelf.Sector
-                        // value will remain at whatever it was when he completed his previous flying lap. Even though we might have no sector data for this
-                        // out-lap. This really fcks things up because we end up with 2 copies of the best lap, but with a some of sector data missing from one.
-                        // So...
-                        // When the last proper laptime is completed we'll have already added another OpponentLapData element, ready to hold the next lap. This
-                        // OpponentLapData element needs to be deleted IF the next provided laptime is the same as the laptime in the OpponentLapData element before 
-                        // this one (length - 2), and this OpponentLapData element doesn't have all the sector data. I think...
-                        Boolean canCompleteLap = true;
-                        if (opponentData.OpponentLapData.Count > 1)
-                        {
-                            LapData previousMinusOneLapData = opponentData.OpponentLapData[opponentData.OpponentLapData.Count - 2];
-                            LapData previousLapData = opponentData.OpponentLapData[opponentData.OpponentLapData.Count - 1];
-                            if (completedLapTime != -1 && previousMinusOneLapData.LapTime == completedLapTime && previousLapData.SectorTimes.Count < 2)
-                            {
-                                Console.WriteLine("deleting an unfinished opponent lap for car in position " + racePosition);
-                                opponentData.OpponentLapData.Remove(previousLapData);
-                                canCompleteLap = false;
-                            }
-                        }
-                        if (canCompleteLap)
-                        {
-                            opponentData.CompleteLapWithProvidedLapTime(racePosition, sessionRunningTime, completedLapTime,
-                                lapIsValid && validSpeed, false, 20, 20, sessionLengthIsTime, sessionTimeRemaining);
-                        }
+                        opponentData.CompleteLapWithProvidedLapTime(racePosition, sessionRunningTime, completedLapTime,
+                            lapIsValid && validSpeed, false, 20, 20, sessionLengthIsTime, sessionTimeRemaining);
                     }
                     opponentData.StartNewLap(completedLaps + 1, racePosition, isInPits, sessionRunningTime, false, 20, 20);
                     opponentData.IsNewLap = true;

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -678,7 +678,7 @@ namespace CrewChiefV4.rFactor1
                 opponent.CompletedLaps = vehicle.totalLaps;
                 opponent.CurrentSectorNumber = vehicle.sector == 0 ? 3 : vehicle.sector;
                 Boolean isNewSector = currentGameState.SessionData.IsNewSession || (opponentPrevious != null && opponentPrevious.CurrentSectorNumber != opponent.CurrentSectorNumber);
-                opponent.IsNewLap = currentGameState.SessionData.IsNewSession || (isNewSector && opponent.CurrentSectorNumber == 1);
+                opponent.IsNewLap = currentGameState.SessionData.IsNewSession || (isNewSector && opponent.CurrentSectorNumber == 1 && opponent.CompletedLaps > 0);
                 opponent.Speed = vehicle.speed;
                 opponent.DistanceRoundTrack = vehicle.lapDist;
                 opponent.WorldPosition = new float[] { vehicle.pos.x, vehicle.pos.z };

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -732,7 +732,7 @@ namespace CrewChiefV4.rFactor1
                 {
                     opponent.setInLap();
                     LapData currentLapData = opponent.getCurrentLapData();
-                    int sector3Position = currentLapData != null ? currentLapData.SectorPositions[2] : opponent.Position;
+                    int sector3Position = currentLapData != null && currentLapData.SectorPositions[2] > 0 ? currentLapData.SectorPositions[2] : opponent.Position;
                     if (sector3Position == 1)
                     {
                         currentGameState.PitData.LeaderIsPitting = true;

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -327,7 +327,7 @@ namespace CrewChiefV4.rFactor1
             if (currentGameState.SessionData.IsNewLap)
             {
                 currentGameState.SessionData.playerCompleteLapWithProvidedLapTime(currentGameState.SessionData.Position, currentGameState.SessionData.SessionRunningTime,
-                        lastSectorTime, lastSectorTime > 0, false, shared.trackTemp, shared.ambientTemp, currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining);
+                        lastSectorTime, lastSectorTime > 0, false, shared.trackTemp, shared.ambientTemp, currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining, 3);
                 currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1, currentGameState.SessionData.Position, player.inPits == 1 || player.lapDist < 0, currentGameState.SessionData.SessionRunningTime, false, shared.trackTemp, shared.ambientTemp);
             }
             else if (currentGameState.SessionData.IsNewSector)
@@ -719,7 +719,8 @@ namespace CrewChiefV4.rFactor1
                 if (opponent.IsNewLap)
                 {
                     opponent.CompleteLapWithProvidedLapTime(opponent.Position, currentGameState.SessionData.SessionRunningTime,
-                            lastSectorTime, lastSectorTime > 0, false, shared.trackTemp, shared.ambientTemp, currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining);
+                            lastSectorTime, lastSectorTime > 0, false, shared.trackTemp, shared.ambientTemp, currentGameState.SessionData.SessionHasFixedTime, 
+                            currentGameState.SessionData.SessionTimeRemaining, 3);
                     opponent.StartNewLap(opponent.CompletedLaps + 1, opponent.Position, vehicle.inPits == 1 || opponent.DistanceRoundTrack < 0, currentGameState.SessionData.SessionRunningTime, false, shared.trackTemp, shared.ambientTemp);
                 }
                 else if (isNewSector)

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -332,8 +332,9 @@ namespace CrewChiefV4.rFactor1
             }
             else if (currentGameState.SessionData.IsNewSector)
             {
-                currentGameState.SessionData.playerAddCumulativeSectorData(currentGameState.SessionData.Position, lastSectorTime, currentGameState.SessionData.SessionRunningTime,
-                    lastSectorTime > 0 || (currentGameState.SessionData.SectorNumber >= 2 && player.totalLaps == 1), false, shared.trackTemp, shared.ambientTemp);
+                currentGameState.SessionData.playerAddCumulativeSectorData(previousGameState.SessionData.SectorNumber, currentGameState.SessionData.Position, lastSectorTime,
+                    currentGameState.SessionData.SessionRunningTime,  lastSectorTime > 0 || (currentGameState.SessionData.SectorNumber >= 2 && player.totalLaps == 1), 
+                    false, shared.trackTemp, shared.ambientTemp);
             }
             currentGameState.SessionData.SessionTimesAtEndOfSectors = previousGameState != null ? previousGameState.SessionData.SessionTimesAtEndOfSectors : new SessionData().SessionTimesAtEndOfSectors;
             if (currentGameState.SessionData.IsNewSector && !currentGameState.SessionData.IsNewSession)
@@ -723,14 +724,14 @@ namespace CrewChiefV4.rFactor1
                 }
                 else if (isNewSector)
                 {
-                    opponent.AddCumulativeSectorData(opponent.Position, lastSectorTime, currentGameState.SessionData.SessionRunningTime,
+                    opponent.AddCumulativeSectorData(opponentPrevious.CurrentSectorNumber, opponent.Position, lastSectorTime, currentGameState.SessionData.SessionRunningTime,
                         lastSectorTime > 0 || (opponent.CurrentSectorNumber >= 2 && vehicle.totalLaps == 1), false, shared.trackTemp, shared.ambientTemp);
                 }
                 if (vehicle.inPits == 1 && opponent.CurrentSectorNumber == 3 && opponentPrevious != null && !opponentPrevious.isEnteringPits())
                 {
                     opponent.setInLap();
                     LapData currentLapData = opponent.getCurrentLapData();
-                    int sector3Position = currentLapData != null && currentLapData.SectorPositions.Count > 2 ? currentLapData.SectorPositions[2] : opponent.Position;
+                    int sector3Position = currentLapData != null ? currentLapData.SectorPositions[2] : opponent.Position;
                     if (sector3Position == 1)
                     {
                         currentGameState.PitData.LeaderIsPitting = true;

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -768,6 +768,7 @@ namespace CrewChiefV4.rFactor2
                 else if (isNewSector && lastSectorTime > 0.0f)
                 {
                     opponent.AddCumulativeSectorData(
+                        opponentPrevious.CurrentSectorNumber,
                         opponent.Position,
                         lastSectorTime,
                         csd.SessionRunningTime,
@@ -784,7 +785,7 @@ namespace CrewChiefV4.rFactor2
                 {
                     opponent.setInLap();
                     var currentLapData = opponent.getCurrentLapData();
-                    int sector3Position = currentLapData != null && currentLapData.SectorPositions.Count > 2
+                    int sector3Position = currentLapData != null 
                                             ? currentLapData.SectorPositions[2]
                                             : opponent.Position;
 
@@ -1147,6 +1148,7 @@ namespace CrewChiefV4.rFactor2
             else if (csd.IsNewSector && lastSectorTime > 0.0f)
             {
                 csd.playerAddCumulativeSectorData(
+                    psd.SectorNumber,
                     csd.Position,
                     lastSectorTime,
                     csd.SessionRunningTime,

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -786,7 +786,7 @@ namespace CrewChiefV4.rFactor2
                 {
                     opponent.setInLap();
                     var currentLapData = opponent.getCurrentLapData();
-                    int sector3Position = currentLapData != null 
+                    int sector3Position = currentLapData != null && currentLapData.SectorPositions[2] > 0
                                             ? currentLapData.SectorPositions[2]
                                             : opponent.Position;
 

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -721,7 +721,7 @@ namespace CrewChiefV4.rFactor2
                 opponent.CurrentSectorNumber = vehicle.mSector == 0 ? 3 : vehicle.mSector;
 
                 var isNewSector = csd.IsNewSession || (opponentPrevious != null && opponentPrevious.CurrentSectorNumber != opponent.CurrentSectorNumber);
-                opponent.IsNewLap = csd.IsNewSession || (isNewSector && opponent.CurrentSectorNumber == 1);
+                opponent.IsNewLap = csd.IsNewSession || (isNewSector && opponent.CurrentSectorNumber == 1 && opponent.CompletedLaps > 0);
                 opponent.Speed = (float)vehicle.mSpeed;
                 opponent.DistanceRoundTrack = (float)vehicle.mLapDist;
                 opponent.WorldPosition = new float[] { (float)vehicle.mPos.x, (float)vehicle.mPos.z };

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -754,7 +754,8 @@ namespace CrewChiefV4.rFactor2
                             (float)rf2state.mTrackTemp,
                             (float)rf2state.mAmbientTemp,
                             csd.SessionHasFixedTime,
-                            csd.SessionTimeRemaining);
+                            csd.SessionTimeRemaining,
+                            3);
                     }
                     opponent.StartNewLap(
                         opponent.CompletedLaps + 1,
@@ -1133,7 +1134,8 @@ namespace CrewChiefV4.rFactor2
                         (float)rf2state.mTrackTemp,
                         (float)rf2state.mAmbientTemp,
                         csd.SessionHasFixedTime,
-                        csd.SessionTimeRemaining);
+                        csd.SessionTimeRemaining,
+                        3);
                 }
 
                 csd.playerStartNewLap(

--- a/CrewChiefV4/UserInterface/MainWindow.cs
+++ b/CrewChiefV4/UserInterface/MainWindow.cs
@@ -603,12 +603,12 @@ namespace CrewChiefV4
                             if (CrewChief.gameDefinition.gameEnum == GameEnum.RACE_ROOM) 
                             {
                                 Console.WriteLine("raceroomLayoutId: " + crewChief.currentGameState.SessionData.TrackDefinition.id + ", distanceRoundLap = " +
-                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + crewChief.currentGameState.carClass.getClassIdentifier());
+                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + CarData.RACEROOM_CLASS_ID);
                             }
                             else
                             {
                                 Console.WriteLine("TrackName: " + crewChief.currentGameState.SessionData.TrackDefinition.name + ", distanceRoundLap = " +
-                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + crewChief.currentGameState.carClass.getClassIdentifier());
+                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + CarData.CLASS_ID);
                             }
                         }
                         else

--- a/CrewChiefV4/UserInterface/MainWindow.cs
+++ b/CrewChiefV4/UserInterface/MainWindow.cs
@@ -603,12 +603,12 @@ namespace CrewChiefV4
                             if (CrewChief.gameDefinition.gameEnum == GameEnum.RACE_ROOM) 
                             {
                                 Console.WriteLine("raceroomLayoutId: " + crewChief.currentGameState.SessionData.TrackDefinition.id + ", distanceRoundLap = " +
-                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + CarData.RACEROOM_CLASS_ID);
+                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + crewChief.currentGameState.carClass.getClassIdentifier());
                             }
                             else
                             {
                                 Console.WriteLine("TrackName: " + crewChief.currentGameState.SessionData.TrackDefinition.name + ", distanceRoundLap = " +
-                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + CarData.CLASS_ID);
+                                    crewChief.currentGameState.PositionAndMotionData.DistanceRoundTrack + ", player's car ID: " + crewChief.currentGameState.carClass.getClassIdentifier());
                             }
                         }
                         else


### PR DESCRIPTION
Lots of changes here.

The aim of this is to rationalise some of the timing stuff a bit. The per-sector data is now placed in existing array elements, so we always pass the just-completed sector number and put the data in the appropriate place. This prevents missing sector data screwing things up in the timing calculations (e.g. when a car exits-to-pit part way through a qually lap). R3E qual / practice got particularly messed up here.

We allow a LapData record to exist only if it's complete (has all the expected sector time data) or it's the first lap we've seen for this car (perhaps we joined mid-session). If it fails this check it's just thrown away.

In making this change, I've also changed some of the other timing data recording stuff to make it a bit more consistent. 