### PR TITLE
Lazy load experiement

### DIFF
--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -219,7 +219,7 @@ namespace CrewChiefV4.Audio
             if (this.soundCache == null)
             {
                 soundCache = new SoundCache(new DirectoryInfo(soundFilesPath),
-                    new String[] { "numbers", "pearls_of_wisdom", "spotter", "acknowledge"  }, sweary, allowCaching, selectedPersonalisation);
+                    new String[] { /*"numbers", */"pearls_of_wisdom", "spotter", "acknowledge"  }, sweary, allowCaching, selectedPersonalisation);
             }
             initialised = true;
         }

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -143,7 +143,8 @@ namespace CrewChiefV4.Audio
                             {
                                 soundSet.loadAll();
                             }
-                            Console.WriteLine("Took " + (DateTime.Now - start).TotalMilliseconds + " ms to load voice sounds");
+                            Console.WriteLine("Took " + (DateTime.Now - start).TotalMilliseconds + " ms to load voice sounds, there are now " +
+                            SoundCache.currentSoundsLoaded + " loaded sound files with " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
                         }).Start();
                     }
                 }

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -165,11 +165,16 @@ namespace CrewChiefV4.Audio
 
         public static void loadDriverNameSounds(List<String> names)
         {
+            int loadedCount = 0;
             foreach (String name in names)
             {
-                loadDriverNameSound(name);
+                if (sortedAvailableDriverNames.BinarySearch(name) >= 0)
+                {
+                    loadedCount++;
+                    loadDriverNameSound(name);
+                }
             }
-            Console.WriteLine("loaded " + names.Count + " driver names There are now" +
+            Console.WriteLine("loaded " + loadedCount + " driver name sounds. There are now" +
                 SoundCache.currentSoundsLoaded + " sound files loaded with " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
         }
 

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -169,6 +169,8 @@ namespace CrewChiefV4.Audio
             {
                 loadDriverNameSound(name);
             }
+            Console.WriteLine("loaded " + names.Count + " driver names There are now" +
+                SoundCache.currentSoundsLoaded + " sound files loaded with " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
         }
 
         public static void loadDriverNameSound(String name)

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -168,11 +168,8 @@ namespace CrewChiefV4.Audio
             int loadedCount = 0;
             foreach (String name in names)
             {
-                if (sortedAvailableDriverNames.BinarySearch(name) >= 0)
-                {
-                    loadedCount++;
-                    loadDriverNameSound(name);
-                }
+                loadedCount++;
+                loadDriverNameSound(name);
             }
             Console.WriteLine("loaded " + loadedCount + " driver name sounds. There are now" +
                 SoundCache.currentSoundsLoaded + " sound files loaded with " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
@@ -180,7 +177,8 @@ namespace CrewChiefV4.Audio
 
         public static void loadDriverNameSound(String name)
         {
-            if (allowCaching && singleSounds.ContainsKey(name))
+            // if the name is in the sortedAvailableDriverNames array then we have a sound file for it, so we can load it
+            if (allowCaching && sortedAvailableDriverNames.BinarySearch(name) >= 0)
             {
                 singleSounds[name].loadAndCache(true);
             }

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -143,7 +143,7 @@ namespace CrewChiefV4.Audio
                             {
                                 soundSet.loadAll();
                             }
-                            Console.WriteLine("Took " + (DateTime.Now - start).TotalMilliseconds + " ms to load voice sounds, there are now " +
+                            Console.WriteLine("Took " + (DateTime.Now - start).TotalSeconds.ToString("0.00") + " s to load voice sounds, there are now " +
                             SoundCache.currentSoundsLoaded + " loaded sound files with " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
                         }).Start();
                     }
@@ -482,7 +482,6 @@ namespace CrewChiefV4.Audio
                     {
                         foreach (DirectoryInfo prefixesAndSuffixesFolder in prefixesAndSuffixesFolders[0].GetDirectories())
                         {
-                            Boolean alwaysKeepCached = allowCaching && this.eventTypesToKeepCached.Contains(prefixesAndSuffixesFolder.Name);
                             // always keep the personalisations cached as they're reused frequently
                             SoundSet soundSet = new SoundSet(prefixesAndSuffixesFolder, this.useSwearyMessages, allowCaching, allowCaching, allowCaching, true);
                             if (soundSet.hasSounds)

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -171,7 +171,7 @@ namespace CrewChiefV4.Audio
                 loadedCount++;
                 loadDriverNameSound(name);
             }
-            Console.WriteLine("loaded " + loadedCount + " driver name sounds. There are now" +
+            Console.WriteLine("loaded " + loadedCount + " driver name sounds. There are now " +
                 SoundCache.currentSoundsLoaded + " sound files loaded with " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
         }
 
@@ -328,7 +328,6 @@ namespace CrewChiefV4.Audio
                 {
                     dynamicLoadedSounds.Remove(purged);
                 }
-                SoundCache.activeSoundPlayers = SoundCache.activeSoundPlayers - purgeCount;
                 Console.WriteLine("Purged " + purgedList.Count + " sounds, there are now " + SoundCache.activeSoundPlayers + " active SoundPlayer objects");
             }
         }

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -33,7 +33,7 @@ namespace CrewChiefV4.Audio
         public static int currentSoundsLoaded;
         public static int activeSoundPlayers;
         public static int prefixesAndSuffixesCount = 0;
-
+        
         public static String OPTIONAL_PREFIX_IDENTIFIER = "op_prefix";
         public static String OPTIONAL_SUFFIX_IDENTIFIER = "op_suffix";
         public static String REQUIRED_PREFIX_IDENTIFIER = "rq_prefix";
@@ -435,7 +435,7 @@ namespace CrewChiefV4.Audio
                     foreach (DirectoryInfo eventDetailFolder in eventDetailFolders)
                     {
                         String fullEventName = eventFolder.Name + "/" + eventDetailFolder.Name;
-                        SoundSet soundSet = new SoundSet(eventDetailFolder, this.useSwearyMessages, false, false, allowCaching, alwaysKeepCached);
+                        SoundSet soundSet = new SoundSet(eventDetailFolder, this.useSwearyMessages, alwaysKeepCached, alwaysKeepCached, allowCaching, alwaysKeepCached);
                         if (soundSet.hasSounds)
                         {
                             sortedAvailableSounds.Add(fullEventName);

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -534,6 +534,8 @@ namespace CrewChiefV4
                                         {
                                             speechRecogniser.addOpponentSpeechRecognition(usableDriverNames, enableDriverNames);
                                         }
+                                        // now load all the sound files for this set of driver names
+                                        SoundCache.loadDriverNameSounds(usableDriverNames);
                                     }
                                 }                                
                             }

--- a/CrewChiefV4/SpeechRecogniser.cs
+++ b/CrewChiefV4/SpeechRecogniser.cs
@@ -321,6 +321,10 @@ namespace CrewChiefV4
                         sre.LoadGrammar(newOpponentGrammar);
                         opponentGrammarList.Add(newOpponentGrammar);
                     }
+                    // This method is called when a new driver appears mid-session. We need to load the sound file for this new driver
+                    // so do it here - nasty nasty hack, need to refactor this. The alternative is to call
+                    // SoundCache.loadDriverNameSound in each of mappers when a new driver is added.
+                    SoundCache.loadDriverNameSound(usableName);
                     driverNamesInUse.Add(rawDriverName);
                 }
             }


### PR DESCRIPTION
Righty...

I think this is ready for merging subject to review. I've remove 'numbers' for the event subtypes that have permanently cached SoundPlayer objects because there are now more than 1000 number sounds. Their file byte arrays are still cached so I think this is OK (it's fairly quick to construct a new SoundPlayer object, which is then cached anyway).

This also fixes the issue where the cache of SoundPlayers was always bigger than the max but nothing could be purged because all the sounds in there were marked as permanent (i.e. the numbers).

The driver names are also lazy-loaded here (again, eager load the file bytes in a background Thread and load the SoundPlayers for each driver at session-start).

I've done enough testing with starting a session while the background Thread is still reading all the sound files