### PR TITLE
work-around for missing session end triggers in RF1 and RF2 when skipping to next session

### DIFF
--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -531,6 +531,8 @@ namespace CrewChiefV4
                         gameStateMapper.versionCheck(rawGameData);
 
                         GameStateData nextGameState = null;
+                        // hold the last session phase - we need it to detect early session exit in RF1 and RF2
+                        SessionPhase lastSessionPhase = currentGameState == null ? SessionPhase.Unavailable : currentGameState.SessionData.SessionPhase;
                         try
                         {
                             nextGameState = gameStateMapper.mapToGameStateData(rawGameData, currentGameState);
@@ -539,16 +541,25 @@ namespace CrewChiefV4
                         {
                             Console.WriteLine("Error mapping game data: " + e.Message + ", " + e.StackTrace);
                         }
+
+                        // special case for RF1 and RF2 - early session end stops the mapper from completing (the most recent shared memory data is bollocks). 
+                        // We catch this immediately in the mapper and return the previous game state with the session phase modified
+                        Boolean rFactorSessionEndCheck = (gameDefinition.gameEnum == GameEnum.RF1 || gameDefinition.gameEnum == GameEnum.RF2_64BIT) && 
+                            nextGameState == currentGameState && 
+                            lastSessionPhase != SessionPhase.Unavailable && 
+                            lastSessionPhase != SessionPhase.Finished && 
+                            currentGameState.SessionData.SessionPhase == SessionPhase.Finished;
+
                         // if we're paused or viewing another car, the mapper will just return the previous game state so we don't lose all the
                         // persistent state information. If this is the case, don't process any stuff
-                        if (nextGameState != null && nextGameState != currentGameState)
+                        if (nextGameState != null && (rFactorSessionEndCheck || nextGameState != currentGameState))
                         {
                             previousGameState = currentGameState;
                             currentGameState = nextGameState;
                             if (!sessionFinished && currentGameState.SessionData.SessionPhase == SessionPhase.Finished
                                 && previousGameState != null)
                             {
-                                Console.WriteLine("Session finished");
+                                Console.WriteLine("Session finished, position = " + currentGameState.SessionData.Position);
                                 audioPlayer.purgeQueues();
                                 if (displaySessionLapTimes)
                                 {

--- a/CrewChiefV4/Events/SessionEndMessages.cs
+++ b/CrewChiefV4/Events/SessionEndMessages.cs
@@ -29,6 +29,8 @@ namespace CrewChiefV4.Events
 
         private AudioPlayer audioPlayer;
 
+        private int minSessionRunTimeForEndMessages = 60;
+
         public SessionEndMessages(AudioPlayer audioPlayer)
         {
             this.audioPlayer = audioPlayer;
@@ -44,7 +46,7 @@ namespace CrewChiefV4.Events
             }
             if (sessionType == SessionType.Race)
             {
-                if (sessionRunningTime > 60 || completedLaps > 0)
+                if (sessionRunningTime >= minSessionRunTimeForEndMessages || completedLaps > 0)
                 {
                     if (lastSessionPhase == SessionPhase.Finished)
                     {
@@ -58,12 +60,12 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    Console.WriteLine("skipping race session end message because it didn't run for a lap or a minute");
+                    Console.WriteLine("skipping race session end message because it didn't run for a lap or " + minSessionRunTimeForEndMessages + " seconds");
                 }
             }
             else if (sessionType == SessionType.Practice || sessionType == SessionType.Qualify)
             {
-                if (sessionRunningTime > 60)
+                if (sessionRunningTime >= minSessionRunTimeForEndMessages)
                 {
                     if (lastSessionPhase == SessionPhase.Green || lastSessionPhase == SessionPhase.FullCourseYellow || 
                         lastSessionPhase == SessionPhase.Finished || lastSessionPhase == SessionPhase.Checkered)
@@ -77,7 +79,7 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    Console.WriteLine("skipping non-race session end message because the session didn't run for a minute");
+                    Console.WriteLine("skipping non-race session end message because the session didn't run for " + minSessionRunTimeForEndMessages + " seconds");
                 }
             }
         }

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -72,12 +72,25 @@ namespace CrewChiefV4.rFactor1
             // no session data
             if (shared.numVehicles == 0)
             {
-                isOfflineSession = true;
-                distanceOffTrack = 0;
-                isApproachingTrack = false;
-                wheelCircumference = new float[] { 0, 0 };
-                previousGameState = null;
-                return null;
+                // if we skip to next session the session phase never goes to 'finished'. We do, however, see the numVehicles drop to zero.
+                // If we have a previous game state and it's in a valid phase here, update it to Finished and return it. This requires some
+                // additional logic in the main CrewChief loop (because this means current and previous game state are the same object).
+                if (previousGameState != null && previousGameState.SessionData.SessionType != SessionType.Unavailable &&
+                    previousGameState.SessionData.SessionPhase != SessionPhase.Finished &&
+                    previousGameState.SessionData.SessionPhase != SessionPhase.Unavailable)
+                {
+                    previousGameState.SessionData.SessionPhase = SessionPhase.Finished;
+                    return previousGameState;
+                }
+                else
+                {
+                    isOfflineSession = true;
+                    distanceOffTrack = 0;
+                    isApproachingTrack = false;
+                    wheelCircumference = new float[] { 0, 0 };
+                    previousGameState = null;
+                    return null;
+                }
             }
             // game is paused or other window has taken focus
             if (shared.deltaTime >= 0.56)
@@ -134,7 +147,6 @@ namespace CrewChiefV4.rFactor1
                 shared.session >= 5 && shared.session <= 8 ? shared.session - 5 :
                 shared.session >= 10 && shared.session <= 13 ? shared.session - 10 : 0;
             currentGameState.SessionData.SessionType = mapToSessionType(shared);
-           
             currentGameState.SessionData.SessionPhase = mapToSessionPhase((rFactor1Constant.rfGamePhase)shared.gamePhase,
                 currentGameState.SessionData.SessionType, ref player);
 

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -134,18 +134,28 @@ namespace CrewChiefV4.rFactor2
             // no session data
             if (shared.scoring.mScoringInfo.mNumVehicles == 0)
             {
-                this.isOfflineSession = true;
-                this.distanceOffTrack = 0;
-                this.isApproachingTrack = false;
-
-                if (pgs != null)
+                // if we skip to next session the session phase never goes to 'finished'. We do, however, see the numVehicles drop to zero.
+                // If we have a previous game state and it's in a valid phase here, update it to Finished and return it. This requires some
+                // additional logic in the main CrewChief loop (because this means current and previous game state are the same object).
+                if (pgs != null && pgs.SessionData.SessionType != SessionType.Unavailable && 
+                    pgs.SessionData.SessionPhase != SessionPhase.Finished && pgs.SessionData.SessionPhase != SessionPhase.Unavailable)
                 {
-                    // In rF2 user can quit practice session and we will never know
-                    // about it.  Mark previous game state with Unavailable flags.
-                    pgs.SessionData.SessionType = SessionType.Unavailable;
-                    pgs.SessionData.SessionPhase = SessionPhase.Unavailable;
+                    pgs.SessionData.SessionPhase = SessionPhase.Finished;
                 }
+                else
+                {
+                    this.isOfflineSession = true;
+                    this.distanceOffTrack = 0;
+                    this.isApproachingTrack = false;
 
+                    if (pgs != null)
+                    {
+                        // In rF2 user can quit practice session and we will never know
+                        // about it.  Mark previous game state with Unavailable flags.
+                        pgs.SessionData.SessionType = SessionType.Unavailable;
+                        pgs.SessionData.SessionPhase = SessionPhase.Unavailable;
+                    }
+                }
                 return pgs;
             }
 


### PR DESCRIPTION
this appears to work for RF1. I've ported the hack to the RF2 mapper but haven't tested it.

It's not pretty but detecting when the numCars goes to zero (a side effect of pressing "next session") allows us to update the SessionPhase in the *previous* game state, and pass it back to the main CrewChief loop. I've had to add an additional check to allow this case to be processed in CrewChief.cs so it's a little bit invasive and not pretty.

See what you think :)