### PR TITLE
if the last sector / laptime is identical to the previous version, assume the game hasn't updated it and invalidate the lap

### DIFF
--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -549,6 +549,14 @@ namespace CrewChiefV4.RaceRoom
                     {
                         if (participantStruct.TrackSector == 1)
                         {
+                            // if the player's sector time is invalidated the game won't update SectorTimePreviousSelf so if the reported time is identical
+                            // to the previous time assume it's an invalid sector:
+                            if (currentGameState.SessionData.CurrentLapIsValid && 
+                                participantStruct.SectorTimePreviousSelf.Sector3 == currentGameState.SessionData.LastSector3Time)
+                            {
+                                currentGameState.SessionData.CurrentLapIsValid = false;
+                            }
+
                             if (currentGameState.SessionData.SessionTimesAtEndOfSectors[3] != -1)
                             {
                                 currentGameState.SessionData.LapTimePreviousEstimateForInvalidLap = currentGameState.SessionData.SessionRunningTime - currentGameState.SessionData.SessionTimesAtEndOfSectors[3];
@@ -578,6 +586,14 @@ namespace CrewChiefV4.RaceRoom
                         }
                         else if (participantStruct.TrackSector == 2)
                         {
+                            // if the player's sector time is invalidated the game won't update SectorTimePreviousSelf so if the reported time is identical
+                            // to the previous time assume it's an invalid sector:
+                            if (currentGameState.SessionData.CurrentLapIsValid &&
+                                participantStruct.SectorTimePreviousSelf.Sector1 == currentGameState.SessionData.LastSector1Time)
+                            {
+                                currentGameState.SessionData.CurrentLapIsValid = false;
+                            }
+
                             currentGameState.SessionData.SessionTimesAtEndOfSectors[1] = currentGameState.SessionData.SessionRunningTime;
                             if (participantStruct.SectorTimeCurrentSelf.Sector1 > 0 && currentGameState.SessionData.CurrentLapIsValid)
                             {
@@ -594,6 +610,14 @@ namespace CrewChiefV4.RaceRoom
                         }
                         else if (participantStruct.TrackSector == 3)
                         {
+                            // if the player's sector time is invalidated the game won't update SectorTimePreviousSelf so if the reported time is identical
+                            // to the previous time assume it's an invalid sector:
+                            if (currentGameState.SessionData.CurrentLapIsValid &&
+                                participantStruct.SectorTimePreviousSelf.Sector2 == currentGameState.SessionData.LastSector2Time)
+                            {
+                                currentGameState.SessionData.CurrentLapIsValid = false;
+                            }
+
                             currentGameState.SessionData.SessionTimesAtEndOfSectors[2] = currentGameState.SessionData.SessionRunningTime;
                             if (participantStruct.SectorTimeCurrentSelf.Sector2 > 0 && participantStruct.SectorTimeCurrentSelf.Sector1 > 0 &&
                                  currentGameState.SessionData.CurrentLapIsValid)
@@ -1553,8 +1577,17 @@ namespace CrewChiefV4.RaceRoom
                 {
                     if (opponentData.OpponentLapData.Count > 0)
                     {
-                        opponentData.CompleteLapWithProvidedLapTime(racePosition, sessionRunningTime, completedLapTime,
-                            lapIsValid && validSpeed, false, 20, 20, sessionLengthIsTime, sessionTimeRemaining, 3);
+                        // if the opponent hasn't set a valid time, the game will not update the lastSector3Time, so we check to see if this has changed - 
+                        // if it's identical to the previous time, assume it's invalid
+                        if (opponentData.LastLapTime == completedLapTime)
+                        {
+                            lapIsValid = false;
+                        }
+                        else
+                        {
+                            opponentData.CompleteLapWithProvidedLapTime(racePosition, sessionRunningTime, completedLapTime,
+                                lapIsValid && validSpeed, false, 20, 20, sessionLengthIsTime, sessionTimeRemaining, 3);
+                        }
                     }
                     opponentData.StartNewLap(completedLaps + 1, racePosition, isInPits, sessionRunningTime, false, 20, 20);
                     opponentData.IsNewLap = true;

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -549,14 +549,6 @@ namespace CrewChiefV4.RaceRoom
                     {
                         if (participantStruct.TrackSector == 1)
                         {
-                            // if the player's sector time is invalidated the game won't update SectorTimePreviousSelf so if the reported time is identical
-                            // to the previous time assume it's an invalid sector:
-                            if (currentGameState.SessionData.CurrentLapIsValid && 
-                                participantStruct.SectorTimePreviousSelf.Sector3 == currentGameState.SessionData.LastSector3Time)
-                            {
-                                currentGameState.SessionData.CurrentLapIsValid = false;
-                            }
-
                             if (currentGameState.SessionData.SessionTimesAtEndOfSectors[3] != -1)
                             {
                                 currentGameState.SessionData.LapTimePreviousEstimateForInvalidLap = currentGameState.SessionData.SessionRunningTime - currentGameState.SessionData.SessionTimesAtEndOfSectors[3];
@@ -586,14 +578,6 @@ namespace CrewChiefV4.RaceRoom
                         }
                         else if (participantStruct.TrackSector == 2)
                         {
-                            // if the player's sector time is invalidated the game won't update SectorTimePreviousSelf so if the reported time is identical
-                            // to the previous time assume it's an invalid sector:
-                            if (currentGameState.SessionData.CurrentLapIsValid &&
-                                participantStruct.SectorTimePreviousSelf.Sector1 == currentGameState.SessionData.LastSector1Time)
-                            {
-                                currentGameState.SessionData.CurrentLapIsValid = false;
-                            }
-
                             currentGameState.SessionData.SessionTimesAtEndOfSectors[1] = currentGameState.SessionData.SessionRunningTime;
                             if (participantStruct.SectorTimeCurrentSelf.Sector1 > 0 && currentGameState.SessionData.CurrentLapIsValid)
                             {
@@ -610,14 +594,6 @@ namespace CrewChiefV4.RaceRoom
                         }
                         else if (participantStruct.TrackSector == 3)
                         {
-                            // if the player's sector time is invalidated the game won't update SectorTimePreviousSelf so if the reported time is identical
-                            // to the previous time assume it's an invalid sector:
-                            if (currentGameState.SessionData.CurrentLapIsValid &&
-                                participantStruct.SectorTimePreviousSelf.Sector2 == currentGameState.SessionData.LastSector2Time)
-                            {
-                                currentGameState.SessionData.CurrentLapIsValid = false;
-                            }
-
                             currentGameState.SessionData.SessionTimesAtEndOfSectors[2] = currentGameState.SessionData.SessionRunningTime;
                             if (participantStruct.SectorTimeCurrentSelf.Sector2 > 0 && participantStruct.SectorTimeCurrentSelf.Sector1 > 0 &&
                                  currentGameState.SessionData.CurrentLapIsValid)


### PR DESCRIPTION
R3E only:

looks like LastSectorXTime doesn't get nuked if the sector / lap is invalidated - it simply doesn't get updated from its previous value. So if we finish a sector / lap and the time for that sector / lap is identical to the previous one, invalidate it.

Note we have to keep the time - we can't discard it even though it's bollocks. This is because the next lap might also be invalid (if we changed it to -1 and the next lap was also invalid, the game would continue sending stale data but we won't know it's stale).

Invalid laps aren't announced or used in timing stuff, but this may make fuel calc inaccurate when this happens to the player (but I've not see it happen to the player yet). 

I fucking *hate* all this timing horseshit and having to guess "when is a time not a time". It has made me grumpy.