### PR TITLE
Dynamic class warning time

### DIFF
--- a/CrewChiefV4/App.config
+++ b/CrewChiefV4/App.config
@@ -797,10 +797,10 @@
         <value>True</value>
       </setting>
       <setting name="target_warning_time_for_faster_class_car" serializeAs="String">
-        <value>10</value>
+        <value>15</value>
       </setting>
       <setting name="target_warning_time_for_slower_class_car" serializeAs="String">
-        <value>5</value>
+        <value>15</value>
       </setting>
     </CrewChiefV4.Properties.Settings>
   </userSettings>

--- a/CrewChiefV4/App.config
+++ b/CrewChiefV4/App.config
@@ -796,6 +796,12 @@
       <setting name="allow_macros_to_trigger_automatically" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="target_warning_time_for_faster_class_car" serializeAs="String">
+        <value>10</value>
+      </setting>
+      <setting name="target_warning_time_for_slower_class_car" serializeAs="String">
+        <value>5</value>
+      </setting>
     </CrewChiefV4.Properties.Settings>
   </userSettings>
 </configuration>

--- a/CrewChiefV4/Events/MulticlassWarnings.cs
+++ b/CrewChiefV4/Events/MulticlassWarnings.cs
@@ -658,8 +658,7 @@ namespace CrewChiefV4.Events
                         if (opponentClassAverageSpeed > playerClassAverageSpeed)
                         {
                             separationForFasterClassWarning[carClass] =
-                                Math.Max(fasterCarWarningZoneStartMin, targetWarningTimeForFasterClass * (opponentClassAverageSpeed - playerClassAverageSpeed) + classSeparationAdjustment#
-                                );
+                                Math.Max(fasterCarWarningZoneStartMin, targetWarningTimeForFasterClass * (opponentClassAverageSpeed - playerClassAverageSpeed) + classSeparationAdjustment);
                         }
                         else
                         {

--- a/CrewChiefV4/Events/MulticlassWarnings.cs
+++ b/CrewChiefV4/Events/MulticlassWarnings.cs
@@ -15,6 +15,13 @@ namespace CrewChiefV4.Events
         private Dictionary<CarData.CarClass, float> separationForFasterClassWarning = new Dictionary<CarData.CarClass, float>();
         private Dictionary<CarData.CarClass, float> separationForSlowerClassWarning = new Dictionary<CarData.CarClass, float>();
 
+        // when calling multi-class warnings, our warning target time is the time between calling the warning, and the
+        // gap between the faster and slower car being 'small' - that is, I don't care how long it'll be before I'm passed
+        // by the faster guy, I want to know how long it'll be before he's pressuring me to let him through. So we add this
+        // many metres to the calculated value.
+        // Shit name for this. Use 10 metres because, reasons.
+        private float classSeparationAdjustment = 10f;
+
         private Boolean enableMulticlassWarnings = UserSettings.GetUserSettings().getBoolean("enable_multiclass_messages");
         private int targetWarningTimeForFasterClass = UserSettings.GetUserSettings().getInt("target_warning_time_for_faster_class_car");
         private int targetWarningTimeForSlowerClass = UserSettings.GetUserSettings().getInt("target_warning_time_for_slower_class_car");
@@ -651,13 +658,14 @@ namespace CrewChiefV4.Events
                         if (opponentClassAverageSpeed > playerClassAverageSpeed)
                         {
                             separationForFasterClassWarning[carClass] =
-                                Math.Max(fasterCarWarningZoneStartMin, targetWarningTimeForFasterClass * (opponentClassAverageSpeed - playerClassAverageSpeed));
+                                Math.Max(fasterCarWarningZoneStartMin, targetWarningTimeForFasterClass * (opponentClassAverageSpeed - playerClassAverageSpeed) + classSeparationAdjustment#
+                                );
                         }
                         else
                         {
                             // this will be negative, because we're behind
                             separationForSlowerClassWarning[carClass] =
-                                Math.Min(slowerCarWarningZoneEndMax, targetWarningTimeForSlowerClass * (opponentClassAverageSpeed - playerClassAverageSpeed));
+                                Math.Min(slowerCarWarningZoneEndMax, targetWarningTimeForSlowerClass * (opponentClassAverageSpeed - playerClassAverageSpeed) - classSeparationAdjustment);
                         }
                     }
                 }                

--- a/CrewChiefV4/Properties/Settings.Designer.cs
+++ b/CrewChiefV4/Properties/Settings.Designer.cs
@@ -3121,7 +3121,7 @@ namespace CrewChiefV4.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("10")]
+        [global::System.Configuration.DefaultSettingValueAttribute("15")]
         public int target_warning_time_for_faster_class_car {
             get {
                 return ((int)(this["target_warning_time_for_faster_class_car"]));
@@ -3133,7 +3133,7 @@ namespace CrewChiefV4.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("5")]
+        [global::System.Configuration.DefaultSettingValueAttribute("15")]
         public int target_warning_time_for_slower_class_car {
             get {
                 return ((int)(this["target_warning_time_for_slower_class_car"]));

--- a/CrewChiefV4/Properties/Settings.Designer.cs
+++ b/CrewChiefV4/Properties/Settings.Designer.cs
@@ -3118,5 +3118,29 @@ namespace CrewChiefV4.Properties {
                 this["allow_macros_to_trigger_automatically"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("10")]
+        public int target_warning_time_for_faster_class_car {
+            get {
+                return ((int)(this["target_warning_time_for_faster_class_car"]));
+            }
+            set {
+                this["target_warning_time_for_faster_class_car"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("5")]
+        public int target_warning_time_for_slower_class_car {
+            get {
+                return ((int)(this["target_warning_time_for_slower_class_car"]));
+            }
+            set {
+                this["target_warning_time_for_slower_class_car"] = value;
+            }
+        }
     }
 }

--- a/CrewChiefV4/Properties/Settings.settings
+++ b/CrewChiefV4/Properties/Settings.settings
@@ -777,10 +777,10 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="target_warning_time_for_faster_class_car" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">10</Value>
+      <Value Profile="(Default)">15</Value>
     </Setting>
     <Setting Name="target_warning_time_for_slower_class_car" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">5</Value>
+      <Value Profile="(Default)">15</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/CrewChiefV4/Properties/Settings.settings
+++ b/CrewChiefV4/Properties/Settings.settings
@@ -776,5 +776,11 @@
     <Setting Name="allow_macros_to_trigger_automatically" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="target_warning_time_for_faster_class_car" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">10</Value>
+    </Setting>
+    <Setting Name="target_warning_time_for_slower_class_car" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">5</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CrewChiefV4/ui_text.txt
+++ b/CrewChiefV4/ui_text.txt
@@ -572,3 +572,8 @@ enable_multiclass_messages_help = Play warnings when slower or faster class cars
 
 allow_macros_to_trigger_automatically = Allow automatic macro triggering
 allow_macros_to_trigger_automatically_help = Enable some macros to execute automatically (e.g. R3E pit auto-confirm)
+
+target_warning_time_for_slower_class_car = Multi-class slower car warning time
+target_warning_time_for_slower_class_car_help = Try and warn this many seconds in advance when passing slower class cars
+target_warning_time_for_faster_class_car = Multi-class faster car warning time
+target_warning_time_for_faster_class_car_help = Try and warn this many seconds in advance when being passed by faster class cars


### PR DESCRIPTION
late night coding, might be bollocks.

Goal here is to get a finger-in-air estimate of the distance separation (between you and the another class car) that give us a nice warning time that's not too early and not too late. This is based on average lap speed of the best laps in each class, and a target warning lead-time (we want 15 seconds warning, the average lap speed diff is 10 metres per second, so we call it when he's 150 away)

If we don't have enough data for this, drop back to the old approach. If the calculated gap is too small use a min value (otherwise it'll be warning about cars that are clearly visible and adding no value). In some cases the lap speed difference is small (only a few m/s) so this minimum separation will be used quite a lot