### PR TITLE
R3e lap invalidation fix

### DIFF
--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -898,11 +898,11 @@ namespace CrewChiefV4.RaceRoom
 
                         float secondsSinceLastUpdate = (float)new TimeSpan(currentGameState.Ticks - previousGameState.Ticks).TotalSeconds;
 
-                        // lap invalidation: if we're in sector1, the laptime will start at 0 so we can't use laptime == 0 to 
-                        // detect an invalid lap
-                        Boolean lapInvalidated = participantStruct.CurrentLapValid != 1 ||
-                            (currentOpponentSector == 1 && participantStruct.LapTimeCurrentSelf == -1) ||
-                            (currentOpponentSector > 1 && participantStruct.LapTimeCurrentSelf == 0);
+                        // lap invalidation: at the start of the lap the laptime will be 0, so only check if the time is zero if
+                        // we've actually start this lap. For this we use LapDistance > 1 metre. Bit of an abitrary choice but
+                        // that's we roll at the CCMC
+                        Boolean lapInvalidated = participantStruct.CurrentLapValid != 1 || participantStruct.LapTimeCurrentSelf == -1 ||
+                            (participantStruct.LapDistance > 1 && participantStruct.LapTimeCurrentSelf == 0);
 
                         upateOpponentData(currentOpponentData, currentOpponentRacePosition,
                                 participantStruct.Place, currentOpponentLapsCompleted,

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -898,10 +898,16 @@ namespace CrewChiefV4.RaceRoom
 
                         float secondsSinceLastUpdate = (float)new TimeSpan(currentGameState.Ticks - previousGameState.Ticks).TotalSeconds;
 
+                        // lap invalidation: if we're in sector1, the laptime will start at 0 so we can't use laptime == 0 to 
+                        // detect an invalid lap
+                        Boolean lapInvalidated = participantStruct.CurrentLapValid != 1 ||
+                            (currentOpponentSector == 1 && participantStruct.LapTimeCurrentSelf == -1) ||
+                            (currentOpponentSector > 1 && participantStruct.LapTimeCurrentSelf == 0);
+
                         upateOpponentData(currentOpponentData, currentOpponentRacePosition,
                                 participantStruct.Place, currentOpponentLapsCompleted,
                                 currentOpponentSector, sectorTime, participantStruct.SectorTimePreviousSelf.Sector3,
-                                participantStruct.InPitlane == 1, participantStruct.CurrentLapValid == 1 && participantStruct.LapTimeCurrentSelf != -1,
+                                participantStruct.InPitlane == 1, !lapInvalidated,
                                 currentGameState.SessionData.SessionRunningTime, secondsSinceLastUpdate,
                                 new float[] { participantStruct.Position.X, participantStruct.Position.Z }, previousOpponentWorldPosition,
                                 participantStruct.LapDistance, participantStruct.TireTypeFront, participantStruct.TireSubTypeFront,


### PR DESCRIPTION
had another sector call that was clearly invalid in last night's online race. The previous check was to mark a lap as invalid if the laptime was -1. This also marks a lap as invalid if it's laptime is 0 and we've actually started the lap (distance > 1m). Totally random hack, of course