### PR TITLE
Interrupting

### DIFF
--- a/CrewChiefV4/App.config
+++ b/CrewChiefV4/App.config
@@ -839,7 +839,7 @@
         <value>True</value>
       </setting>
       <setting name="immediate_messages_block_other_messages" serializeAs="String">
-        <value>True</value>
+        <value>False</value>
       </setting>
     </CrewChiefV4.Properties.Settings>
   </userSettings>

--- a/CrewChiefV4/App.config
+++ b/CrewChiefV4/App.config
@@ -838,6 +838,9 @@
       <setting name="enable_opponent_pit_exit_estimates" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="immediate_messages_block_other_messages" serializeAs="String">
+        <value>True</value>
+      </setting>
     </CrewChiefV4.Properties.Settings>
   </userSettings>
 </configuration>

--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -984,7 +984,10 @@ namespace CrewChiefV4.Audio
 
         public Boolean hasMessageInImmediateQueue()
         {
-            return immediateClips.Count > 0;
+            lock (immediateClips)
+            {
+                return immediateClips.Count > 0;
+            }
         }
 
         public void playMessageImmediately(QueuedMessage queuedMessage)

--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -758,7 +758,7 @@ namespace CrewChiefV4.Audio
                                 }
                                 if (!mute)
                                 {
-                                    soundCache.Play(eventName);
+                                    soundCache.Play(eventName, !isImmediateMessages);
                                     timeOfLastMessageEnd = GameStateData.CurrentTime;
                                 }
                                 else
@@ -787,7 +787,7 @@ namespace CrewChiefV4.Audio
                                 {
                                     thisMessage.resolveDelayedContents();
                                 }
-                                soundCache.Play(thisMessage.messageFolders);
+                                soundCache.Play(thisMessage.messageFolders, !isImmediateMessages);
                                 timeOfLastMessageEnd = GameStateData.CurrentTime;
                             }
                             else
@@ -868,7 +868,7 @@ namespace CrewChiefV4.Audio
             if (!mute)
             {
                 var soundToPlay = PlaybackModerator.GetSuggestedBleepStart();
-                soundCache.Play(soundToPlay);
+                soundCache.Play(soundToPlay, false);
             }
         }
 
@@ -878,7 +878,7 @@ namespace CrewChiefV4.Audio
             {
                 if (!mute)
                 {
-                    soundCache.Play("listen_start_sound");
+                    soundCache.Play("listen_start_sound", false);
                 }
             }
         }
@@ -888,7 +888,7 @@ namespace CrewChiefV4.Audio
             if (!mute)
             {
                 var soundToPlay = PlaybackModerator.GetSuggestedBleepShorStart();
-                soundCache.Play(soundToPlay);
+                soundCache.Play(soundToPlay, false);
             }
         }
 
@@ -897,7 +897,7 @@ namespace CrewChiefV4.Audio
             if (!mute)
             {
                 var soundToPlay = PlaybackModerator.GetSuggestedBleepEnd();
-                soundCache.Play(soundToPlay);
+                soundCache.Play(soundToPlay, false);
             }
         }
 
@@ -980,6 +980,11 @@ namespace CrewChiefV4.Audio
                 Thread.Sleep(queuedMessage.secondsDelay * 1000);
                 playMessageImmediately(queuedMessage);
             }).Start();            
+        }
+
+        public Boolean hasMessageInImmediateQueue()
+        {
+            return immediateClips.Count > 0;
         }
 
         public void playMessageImmediately(QueuedMessage queuedMessage)

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -151,6 +151,12 @@ namespace CrewChiefV4.Audio
         //public static void PostProcessSound()
         //{ }
 
+        /*
+         * canInterrupt will be true for regular messages triggered by the app's normal event logic. When a message
+         * is played from the 'immediate' queue this will be false (spotter calls, command responses, some edge cases 
+         * where the message is time-critical). If this flag is true the presence of a message in the immediate queue
+         * will make the app skip this sound if immediate_messages_block_other_messages is enabled.
+         */
         public static bool ShouldPlaySound(SingleSound sound, Boolean canInterrupt)
         {
             if (rejectMessagesWhenTalking 

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -150,13 +150,18 @@ namespace CrewChiefV4.Audio
         //public static void PostProcessSound()
         //{ }
 
-        public static bool ShouldPlaySound(SingleSound sound)
+        public static bool ShouldPlaySound(SingleSound sound, Boolean canInterrupt)
         {
             if (rejectMessagesWhenTalking 
                 && SpeechRecogniser.waitingForSpeech 
                 && MainWindow.voiceOption != MainWindow.VoiceOptionEnum.ALWAYS_ON)
             {
                 PlaybackModerator.Trace(string.Format("Sound {0} rejected because we're in the middle of a voice command", sound.fullPath));
+                return false;
+            }
+
+            if (canInterrupt && audioPlayer.hasMessageInImmediateQueue())
+            {
                 return false;
             }
 
@@ -207,11 +212,11 @@ namespace CrewChiefV4.Audio
 
                 // insert bleep out/in
                 if (PlaybackModerator.insertBeepOutBetweenSpotterAndChief)
-                    PlaybackModerator.audioPlayer.getSoundCache().Play(keyBleepOut);
+                    PlaybackModerator.audioPlayer.getSoundCache().Play(keyBleepOut, false);
 
                 // would be nice to have some slight random silence here
                 if (PlaybackModerator.insertBeepInBetweenSpotterAndChief)
-                    PlaybackModerator.audioPlayer.getSoundCache().Play(keyBleepIn);
+                    PlaybackModerator.audioPlayer.getSoundCache().Play(keyBleepIn, false);
             }
 
             PlaybackModerator.lastSoundWasSpotter = isSpotterSound;

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -162,11 +162,14 @@ namespace CrewChiefV4.Audio
 
             if (canInterrupt)
             {
-                Console.WriteLine("can interrupt sound " + sound.fullPath);
                 if (audioPlayer.hasMessageInImmediateQueue())
                 {
-                    Console.WriteLine("blocking queued messasge because an immediate message is waiting");
+                    Console.WriteLine("blocking queued messasge " + sound.fullPath + " because an immediate message is waiting");
                     return false;
+                }
+                else
+                {
+                    Console.WriteLine("queued messasge " + sound.fullPath + " can play");
                 }
             }
 

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -160,9 +160,14 @@ namespace CrewChiefV4.Audio
                 return false;
             }
 
-            if (canInterrupt && audioPlayer.hasMessageInImmediateQueue())
+            if (canInterrupt)
             {
-                return false;
+                Console.WriteLine("can interrupt sound " + sound.fullPath);
+                if (audioPlayer.hasMessageInImmediateQueue())
+                {
+                    Console.WriteLine("blocking queued messasge because an immediate message is waiting");
+                    return false;
+                }
             }
 
             return true;

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -28,6 +28,7 @@ namespace CrewChiefV4.Audio
         private static bool insertBeepOutBetweenSpotterAndChief = UserSettings.GetUserSettings().getBoolean("insert_beep_out_between_spotter_and_chief");
         private static bool insertBeepInBetweenSpotterAndChief = UserSettings.GetUserSettings().getBoolean("insert_beep_in_between_spotter_and_chief");
         private static bool rejectMessagesWhenTalking = UserSettings.GetUserSettings().getBoolean("reject_message_when_talking");
+        private static bool immediateMessagesBlockOtherMessages = UserSettings.GetUserSettings().getBoolean("immediate_messages_block_other_messages");
         private static bool lastSoundWasSpotter = false;
         private static AudioPlayer audioPlayer = null;
 
@@ -160,16 +161,12 @@ namespace CrewChiefV4.Audio
                 return false;
             }
 
-            if (canInterrupt)
+            if (immediateMessagesBlockOtherMessages && canInterrupt)
             {
                 if (audioPlayer.hasMessageInImmediateQueue())
                 {
-                    Console.WriteLine("blocking queued messasge " + sound.fullPath + " because an immediate message is waiting");
+                    PlaybackModerator.Trace(string.Format("blocking queued messasge {0} because an immediate message is waiting", sound.fullPath));
                     return false;
-                }
-                else
-                {
-                    Console.WriteLine("queued messasge " + sound.fullPath + " can play");
                 }
             }
 

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -325,6 +325,12 @@ namespace CrewChiefV4.Audio
             }
         }
 
+        /*
+         * canInterrupt will be true for regular messages triggered by the app's normal event logic. When a message
+         * is played from the 'immediate' queue this will be false (spotter calls, command responses, some edge cases 
+         * where the message is time-critical). If this flag is true the presence of a message in the immediate queue
+         * can make the app skip playing this sound.
+         */
         public void Play(List<String> soundNames, Boolean canInterrupt)
         {           
             SoundSet prefix = null;
@@ -426,6 +432,12 @@ namespace CrewChiefV4.Audio
             }
         }
 
+        /*
+         * canInterrupt will be true for regular messages triggered by the app's normal event logic. When a message
+         * is played from the 'immediate' queue this will be false (spotter calls, command responses, some edge cases 
+         * where the message is time-critical). If this flag is true the presence of a message in the immediate queue
+         * can make the app skip playing this sound.
+         */
         public void Play(String soundName, Boolean canInterrupt)
         {
             List<String> l = new List<String>();
@@ -1152,6 +1164,12 @@ namespace CrewChiefV4.Audio
             }
         }
 
+        /*
+         * canInterrupt will be true for regular messages triggered by the app's normal event logic. When a message
+         * is played from the 'immediate' queue this will be false (spotter calls, command responses, some edge cases 
+         * where the message is time-critical). If this flag is true the presence of a message in the immediate queue
+         * can make the app skip playing this sound.
+         */
         public void Play(Boolean canInterrupt)
         {
             if (!PlaybackModerator.ShouldPlaySound(this, canInterrupt))

--- a/CrewChiefV4/Audio/Sounds.cs
+++ b/CrewChiefV4/Audio/Sounds.cs
@@ -325,7 +325,7 @@ namespace CrewChiefV4.Audio
             }
         }
 
-        public void Play(List<String> soundNames)
+        public void Play(List<String> soundNames, Boolean canInterrupt)
         {           
             SoundSet prefix = null;
             SoundSet suffix = null;
@@ -420,17 +420,17 @@ namespace CrewChiefV4.Audio
                     }
                     else
                     {
-                        singleSound.Play();
+                        singleSound.Play(canInterrupt);
                     }
                 }
             }
         }
 
-        public void Play(String soundName)
+        public void Play(String soundName, Boolean canInterrupt)
         {
             List<String> l = new List<String>();
             l.Add(soundName);
-            Play(l);
+            Play(l, canInterrupt);
         }
 
         public void ExpireCachedSounds()
@@ -1152,9 +1152,9 @@ namespace CrewChiefV4.Audio
             }
         }
 
-        public void Play()
+        public void Play(Boolean canInterrupt)
         {
-            if (!PlaybackModerator.ShouldPlaySound(this))
+            if (!PlaybackModerator.ShouldPlaySound(this, canInterrupt))
                 return;
 
             PlaybackModerator.PreProcessSound(this);

--- a/CrewChiefV4/Events/SmokeTest.cs
+++ b/CrewChiefV4/Events/SmokeTest.cs
@@ -111,21 +111,18 @@ namespace CrewChiefV4.Events
             audioPlayer.playMessage(new QueuedMessage(ConditionsMonitor.folderRainLightDecreasing, 0, this));
             audioPlayer.playMessage(new QueuedMessage(ConditionsMonitor.folderDrizzleDecreasing, 0, this));*/
 
-            /*
             audioPlayer.playMessage(new QueuedMessage(SMOKE_TEST, MessageContents(folderTest), 0, this));
             if (NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck != null)
             {
                 Thread.Sleep(800);
                 audioPlayer.playSpotterMessage(new QueuedMessage(SMOKE_TEST_SPOTTER, MessageContents(NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck), 0, this), false);
             }
-            */
-
             //PlaybackModerator.SetTracing(true /*enabled*/);
             //this.BeepOutInTest();
 
             // pit exit strategy debug stuff to see how it sounds
             
-            List<String> rawDriverNames = new List<string>();
+            /*List<String> rawDriverNames = new List<string>();
             List<MessageFragment> fragments = new List<MessageFragment>();
             fragments.Add(MessageFragment.Text(Strategy.folderClearTrackOnPitExit));
             fragments.Add(MessageFragment.Text(Strategy.folderWeShouldEmergeInPosition));
@@ -135,8 +132,7 @@ namespace CrewChiefV4.Events
             fragments.Add(MessageFragment.Text(Strategy.folderAnd));
             fragments.Add(MessageFragment.Opponent(makeTempDriver("fillingham", rawDriverNames)));
             audioPlayer.playMessage(new QueuedMessage("check", fragments, 0, this));
-            Thread.Sleep(4000);
-            audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderDisableSpotter, 0, null));
+            */
 
             /*
             List<String> rawDriverNames = new List<string>();

--- a/CrewChiefV4/Events/SmokeTest.cs
+++ b/CrewChiefV4/Events/SmokeTest.cs
@@ -111,18 +111,21 @@ namespace CrewChiefV4.Events
             audioPlayer.playMessage(new QueuedMessage(ConditionsMonitor.folderRainLightDecreasing, 0, this));
             audioPlayer.playMessage(new QueuedMessage(ConditionsMonitor.folderDrizzleDecreasing, 0, this));*/
 
+            /*
             audioPlayer.playMessage(new QueuedMessage(SMOKE_TEST, MessageContents(folderTest), 0, this));
             if (NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck != null)
             {
                 Thread.Sleep(800);
                 audioPlayer.playSpotterMessage(new QueuedMessage(SMOKE_TEST_SPOTTER, MessageContents(NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck), 0, this), false);
             }
+            */
+
             //PlaybackModerator.SetTracing(true /*enabled*/);
             //this.BeepOutInTest();
 
             // pit exit strategy debug stuff to see how it sounds
             
-            /*List<String> rawDriverNames = new List<string>();
+            List<String> rawDriverNames = new List<string>();
             List<MessageFragment> fragments = new List<MessageFragment>();
             fragments.Add(MessageFragment.Text(Strategy.folderClearTrackOnPitExit));
             fragments.Add(MessageFragment.Text(Strategy.folderWeShouldEmergeInPosition));
@@ -132,7 +135,8 @@ namespace CrewChiefV4.Events
             fragments.Add(MessageFragment.Text(Strategy.folderAnd));
             fragments.Add(MessageFragment.Opponent(makeTempDriver("fillingham", rawDriverNames)));
             audioPlayer.playMessage(new QueuedMessage("check", fragments, 0, this));
-            */
+            Thread.Sleep(4000);
+            audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderDisableSpotter, 0, null));
 
             /*
             List<String> rawDriverNames = new List<string>();

--- a/CrewChiefV4/Properties/Settings.Designer.cs
+++ b/CrewChiefV4/Properties/Settings.Designer.cs
@@ -3286,5 +3286,17 @@ namespace CrewChiefV4.Properties {
                 this["enable_opponent_pit_exit_estimates"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool immediate_messages_block_other_messages {
+            get {
+                return ((bool)(this["immediate_messages_block_other_messages"]));
+            }
+            set {
+                this["immediate_messages_block_other_messages"] = value;
+            }
+        }
     }
 }

--- a/CrewChiefV4/Properties/Settings.Designer.cs
+++ b/CrewChiefV4/Properties/Settings.Designer.cs
@@ -3289,7 +3289,7 @@ namespace CrewChiefV4.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool immediate_messages_block_other_messages {
             get {
                 return ((bool)(this["immediate_messages_block_other_messages"]));

--- a/CrewChiefV4/Properties/Settings.settings
+++ b/CrewChiefV4/Properties/Settings.settings
@@ -818,5 +818,8 @@
     <Setting Name="enable_opponent_pit_exit_estimates" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="immediate_messages_block_other_messages" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CrewChiefV4/Properties/Settings.settings
+++ b/CrewChiefV4/Properties/Settings.settings
@@ -819,7 +819,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="immediate_messages_block_other_messages" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/CrewChiefV4/ui_text.txt
+++ b/CrewChiefV4/ui_text.txt
@@ -1077,3 +1077,4 @@ enable_opponent_pit_exit_estimates_category = PIT_STOPS_AND_MULTICLASS
 
 immediate_messages_block_other_messages = Spotter and responses block other messages
 immediate_messages_block_other_messages_help = The spotter and command responses block other messages
+immediate_messages_block_other_messages_category = AUDIO_VOICE_AND_CONTROLLERS;SPOTTER

--- a/CrewChiefV4/ui_text.txt
+++ b/CrewChiefV4/ui_text.txt
@@ -1074,3 +1074,6 @@ enable_pit_exit_position_estimates_category = PIT_STOPS_AND_MULTICLASS
 enable_opponent_pit_exit_estimates = Enable opponent pit exit estimates
 enable_opponent_pit_exit_estimates_help = Play pit exit position estimates for opponent cars
 enable_opponent_pit_exit_estimates_category = PIT_STOPS_AND_MULTICLASS
+
+immediate_messages_block_other_messages = Spotter and responses block other messages
+immediate_messages_block_other_messages_help = The spotter and command responses block other messages


### PR DESCRIPTION
if a message is in the immediate queue (spotter / comms response) block all non-immediate sounds from playing. This makes a phrase cut out half way through playing if the spotter wants to interrupt. Can sound bad in some cases, so disabled by default