### PR TITLE
Timing rework

### DIFF
--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -1568,16 +1568,26 @@ namespace CrewChiefV4.assetto
 
             if (currentGameState.PitData.InPitlane)
             {
-                if (currentGameState.SessionData.SectorNumber == ACSGameStateMapper.numberOfSectorsOnTrack)
+                if (previousGameState != null && !previousGameState.PitData.InPitlane)
                 {
+                    if (currentGameState.SessionData.SessionRunningTime > 30 && currentGameState.SessionData.SessionType == SessionType.Race)
+                    {
+                        currentGameState.PitData.NumPitStops++;
+                    }
                     currentGameState.PitData.OnInLap = true;
                     currentGameState.PitData.OnOutLap = false;
                 }
-                else if (currentGameState.SessionData.SectorNumber == 1)
+                else if (currentGameState.SessionData.IsNewLap)
                 {
                     currentGameState.PitData.OnInLap = false;
                     currentGameState.PitData.OnOutLap = true;
                 }
+            }
+            else if (previousGameState != null && previousGameState.PitData.InPitlane)
+            {
+                currentGameState.PitData.OnInLap = false;
+                currentGameState.PitData.OnOutLap = true;
+                currentGameState.PitData.IsAtPitExit = true;
             }
             else if (currentGameState.SessionData.IsNewLap)
             {
@@ -1585,6 +1595,7 @@ namespace CrewChiefV4.assetto
                 currentGameState.PitData.OnInLap = false;
                 currentGameState.PitData.OnOutLap = false;
             }
+
             if (previousGameState != null && currentGameState.PitData.OnOutLap && previousGameState.PitData.InPitlane && !currentGameState.PitData.InPitlane)
             {
                 currentGameState.PitData.IsAtPitExit = true;

--- a/CrewChiefV4/ACS/ACSGameStateMapper.cs
+++ b/CrewChiefV4/ACS/ACSGameStateMapper.cs
@@ -51,8 +51,6 @@ namespace CrewChiefV4.assetto
         private static string expectedVersion = "1.7";
         private static string expectedPluginVersion = "1.0.0";
 
-        public List<LapData> playerLapData = new List<LapData>();
-
         private int lapCountAtSector1End = -1;
 
         // next track conditions sample due after:
@@ -931,8 +929,6 @@ namespace CrewChiefV4.assetto
                         lastSessionTrack == null || lastSessionTrack.name != currentGameState.SessionData.TrackDefinition.name ||
                             (currentGameState.SessionData.SessionHasFixedTime && sessionTimeRemaining > lastSessionTimeRemaining + 1))))
             {
-
-                playerLapData.Clear();
                 Console.WriteLine("New session, trigger...");
                 if (sessionOfSameTypeRestarted)
                 {

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -173,7 +173,8 @@ namespace CrewChiefV4.Audio
                 PlaybackModerator.Trace(string.Format("Sound {0} rejected because other members of the same message have been blocked", singleSound.fullPath));
                 return false;
             }
-            if (rejectMessagesWhenTalking 
+            if (rejectMessagesWhenTalking
+                && soundMetadata.type != SoundType.VOICE_COMMAND_RESPONSE
                 && SpeechRecogniser.waitingForSpeech 
                 && MainWindow.voiceOption != MainWindow.VoiceOptionEnum.ALWAYS_ON)
             {

--- a/CrewChiefV4/Events/Penalties.cs
+++ b/CrewChiefV4/Events/Penalties.cs
@@ -246,6 +246,7 @@ namespace CrewChiefV4.Events
                 }
             }
             else if (currentGameState.PositionAndMotionData.CarSpeed > 1 && playCutTrackWarnings && 
+                !(currentGameState.SessionData.CompletedLaps == 0 && currentGameState.PitData.OnOutLap) &&
                 currentGameState.PenaltiesData.CutTrackWarnings > cutTrackWarningsCount &&
                 currentGameState.PenaltiesData.NumPenalties == previousGameState.PenaltiesData.NumPenalties)  // Make sure we've no new penalty for this cut.
             {
@@ -280,8 +281,9 @@ namespace CrewChiefV4.Events
                     clearPenaltyState();
                 }
             }
-            else if ((currentGameState.PositionAndMotionData.CarSpeed > 1 && playCutTrackWarnings && currentGameState.SessionData.SessionType != SessionType.Race &&
-              !currentGameState.SessionData.CurrentLapIsValid && previousGameState != null && previousGameState.SessionData.CurrentLapIsValid && CrewChief.gameDefinition.gameEnum != GameEnum.IRACING))
+            else if (currentGameState.PositionAndMotionData.CarSpeed > 1 && playCutTrackWarnings && currentGameState.SessionData.SessionType != SessionType.Race &&
+              !currentGameState.SessionData.CurrentLapIsValid && previousGameState != null && previousGameState.SessionData.CurrentLapIsValid && 
+                CrewChief.gameDefinition.gameEnum != GameEnum.IRACING && !(currentGameState.SessionData.CompletedLaps == 0 && currentGameState.PitData.OnOutLap))
             {
                 // JB: don't think we need this block - the previous block should always trigger in preference to this, but we'll leave it here just in case
                 cutTrackWarningsCount = currentGameState.PenaltiesData.CutTrackWarnings;

--- a/CrewChiefV4/Events/Strategy.cs
+++ b/CrewChiefV4/Events/Strategy.cs
@@ -71,7 +71,7 @@ namespace CrewChiefV4.Events
         private float lastAndFirstSectorTimesOnStop = -1;
 
         // an extra check for practice sessions. We only allow the pit benchmark calculation if we've completed
-        // a valid lap that's not our first la and is not a lap where we visited the pits. This prevents the app
+        // a valid lap that's not our first lap and is not a lap where we visited the pits. This prevents the app
         // using the line lap or outlap for its comparison data
         private Boolean hasPracticeLapForComparison = false;
 

--- a/CrewChiefV4/Events/Strategy.cs
+++ b/CrewChiefV4/Events/Strategy.cs
@@ -192,7 +192,8 @@ namespace CrewChiefV4.Events
                 }
             }
 
-            if (waitingForValidDataForBenchmark)
+            if (waitingForValidDataForBenchmark && (currentGameState.SessionData.IsNewLap ||
+                (currentGameState.SessionData.IsNewSector && previousGameState.SessionData.SectorNumber == 1)))
             {
                 if (currentGameState.SessionData.TrackDefinition.name != trackNameForLastPitstopTiming ||
                     !CarData.IsCarClassEqual(currentGameState.carClass, carClassForLastPitstopTiming))

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -472,18 +472,18 @@ namespace CrewChiefV4.GameState
                 restoreTo.PlayerBestLapTimeByTyre.Add(entry.Key, entry.Value);
         }
 
-        public void playerStartNewLap(int lapNumber, int position, Boolean inPits, float gameTimeAtStart)
+        public void playerStartNewLap(int lapNumber, int overallPosition, Boolean inPits, float gameTimeAtStart)
         {
             LapData thisLapData = new LapData();
             thisLapData.GameTimeAtLapStart = gameTimeAtStart;
             thisLapData.OutLap = inPits;
-            thisLapData.PositionAtStart = position;
+            thisLapData.PositionAtStart = overallPosition;
             thisLapData.LapNumber = lapNumber;
             CurrentLapIsValid = true;
             PlayerLapData.Add(thisLapData);
         }
 
-        public void playerCompleteLapWithProvidedLapTime(int classPosition, float gameTimeAtLapEnd, float providedLapTime,
+        public void playerCompleteLapWithProvidedLapTime(int overallPosition, float gameTimeAtLapEnd, float providedLapTime,
             Boolean lapIsValid /*IMPORTANT: this is 'current lap is valid'*/, Boolean inPitLane, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime,
             float sessionTimeRemaining, int numberOfSectors)
         {
@@ -493,12 +493,12 @@ namespace CrewChiefV4.GameState
             }
             CurrentLapIsValid = true;
             formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(providedLapTime).ToString(@"mm\:ss\.fff"));
-            PositionAtStartOfCurrentLap = classPosition;
+            PositionAtStartOfCurrentLap = overallPosition;
             LapData lapData = lapData = PlayerLapData[PlayerLapData.Count - 1];
             
             LapTimePreviousEstimateForInvalidLap = SessionRunningTime - SessionTimesAtEndOfSectors[numberOfSectors - 1];
             LapTimePrevious = providedLapTime;
-            playerAddCumulativeSectorData(numberOfSectors, classPosition, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
+            playerAddCumulativeSectorData(numberOfSectors, overallPosition, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
             lapData.LapTime = providedLapTime;
             lapData.InLap = inPitLane;
 
@@ -528,16 +528,16 @@ namespace CrewChiefV4.GameState
                 }
             }                
         }
-        
 
-        public void playerAddCumulativeSectorData(int sectorNumberJustCompleted, int position, float cumulativeSectorTime,
+
+        public void playerAddCumulativeSectorData(int sectorNumberJustCompleted, int overallPosition, float cumulativeSectorTime,
             float gameTimeAtSectorEnd, Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp)
         {
             SessionTimesAtEndOfSectors[sectorNumberJustCompleted] = gameTimeAtSectorEnd;
             LapData lapData;
             if (PlayerLapData.Count == 0)
             {
-                playerStartNewLap(0, position, true, -1);
+                playerStartNewLap(0, overallPosition, true, -1);
                 lapData = PlayerLapData[0];
                 lapData.hasMissingSectors = true;
                 lapData.IsValid = false;
@@ -617,7 +617,7 @@ namespace CrewChiefV4.GameState
                 }
             }
             lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
-            lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
+            lapData.SectorPositions[sectorNumberJustCompleted - 1] = overallPosition;
             lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
             lapData.Conditions[sectorNumberJustCompleted - 1] = new LapConditions(isRaining, trackTemp, airTemp);
             if (lapData.IsValid && !lapIsValid)

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -360,7 +360,7 @@ namespace CrewChiefV4.GameState
         public int LapsDeltaBehind = -1;
 
         // 0 means we don't know what sector we're in. This is 1-indexed
-        public int SectorNumber = 0;
+        public int SectorNumber = 1;
 
         public Boolean IsNewSector = false;
 
@@ -472,130 +472,159 @@ namespace CrewChiefV4.GameState
                 restoreTo.PlayerBestLapTimeByTyre.Add(entry.Key, entry.Value);
         }
 
-        public void playerStartNewLap(int lapNumber, int position, Boolean inPits, float gameTimeAtStart, Boolean isRaining, float trackTemp, float airTemp)
+        public void playerStartNewLap(int lapNumber, int position, Boolean inPits, float gameTimeAtStart)
         {
             LapData thisLapData = new LapData();
             thisLapData.GameTimeAtLapStart = gameTimeAtStart;
             thisLapData.OutLap = inPits;
             thisLapData.PositionAtStart = position;
             thisLapData.LapNumber = lapNumber;
+            CurrentLapIsValid = true;
             PlayerLapData.Add(thisLapData);
         }
 
-        public void playerCompleteLapWithProvidedLapTime(int position, float gameTimeAtLapEnd, float providedLapTime,
-            Boolean lapIsValid, Boolean inPitLane, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime, float sessionTimeRemaining, int numberOfSectors)
+        public void playerCompleteLapWithProvidedLapTime(int classPosition, float gameTimeAtLapEnd, float providedLapTime,
+            Boolean lapIsValid /*IMPORTANT: this is 'current lap is valid'*/, Boolean inPitLane, Boolean isRaining, float trackTemp, float airTemp, Boolean sessionLengthIsTime,
+            float sessionTimeRemaining, int numberOfSectors)
         {
-            if (PlayerLapData.Count > 0)
+            if (PlayerLapData.Count == 0)
             {
-                LapData lapData = PlayerLapData[PlayerLapData.Count - 1];
-                if (PlayerLapData.Count == 1 || !lapData.hasMissingSectors)
-                {
-                    playerAddCumulativeSectorData(numberOfSectors, position, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
-                    lapData.LapTime = providedLapTime;
-                    lapData.InLap = inPitLane;
-
-                    LapTimePrevious = providedLapTime;
-                    if (lapData.IsValid && (PlayerLapTimeSessionBest == -1 || PlayerLapTimeSessionBest > lapData.LapTime))
-                    {
-                        PlayerLapTimeSessionBestPrevious = PlayerLapTimeSessionBest;
-                        PlayerLapTimeSessionBest = lapData.LapTime;
-
-                        PlayerBestLapSector1Time = lapData.SectorTimes[0];
-                        PlayerBestLapSector2Time = lapData.SectorTimes[1];
-                        PlayerBestLapSector3Time = lapData.SectorTimes[2];
-                    }
-                }
-                else
-                {
-                    PlayerLapData.Remove(lapData);
-                }
-                PreviousLapWasValid = lapData.IsValid;
+                return;
             }
-        }
+            CurrentLapIsValid = true;
+            formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(providedLapTime).ToString(@"mm\:ss\.fff"));
+            PositionAtStartOfCurrentLap = classPosition;
+            LapData lapData = lapData = PlayerLapData[PlayerLapData.Count - 1];
+            
+            LapTimePreviousEstimateForInvalidLap = SessionRunningTime - SessionTimesAtEndOfSectors[numberOfSectors - 1];
+            LapTimePrevious = providedLapTime;
+            playerAddCumulativeSectorData(numberOfSectors, classPosition, providedLapTime, gameTimeAtLapEnd, lapIsValid, isRaining, trackTemp, airTemp);
+            lapData.LapTime = providedLapTime;
+            lapData.InLap = inPitLane;
 
-        public void playerAddCumulativeSectorData(int sectorNumberJustCompleted, int position, float cumulativeSectorTime, float gameTimeAtSectorEnd, Boolean lapIsValid, 
-            Boolean isRaining, float trackTemp, float airTemp)
-        {
-            if (PlayerLapData.Count > 0)
+            LapTimePrevious = providedLapTime;
+            if (lapData.IsValid && !lapData.OutLap && !lapData.InLap && (PlayerLapTimeSessionBest == -1 || PlayerLapTimeSessionBest > lapData.LapTime))
             {
-                LapData lapData = PlayerLapData[PlayerLapData.Count - 1];
+                PlayerLapTimeSessionBestPrevious = PlayerLapTimeSessionBest;
+                PlayerLapTimeSessionBest = lapData.LapTime;
 
-                if (cumulativeSectorTime <= 0)
+                PlayerBestLapSector1Time = lapData.SectorTimes[0];
+                PlayerBestLapSector2Time = lapData.SectorTimes[1];
+                if (numberOfSectors > 2)
                 {
-                    cumulativeSectorTime = gameTimeAtSectorEnd - lapData.GameTimeAtLapStart;
+                    PlayerBestLapSector3Time = lapData.SectorTimes[2];
                 }
-                float thisSectorTime;
-                if (sectorNumberJustCompleted == 3 && lapData.SectorTimes[0] > 0 && lapData.SectorTimes[1] > 0)
+            }
+            PreviousLapWasValid = lapData.IsValid;
+            if (PreviousLapWasValid && LapTimePrevious > 0 && PlayerLapTimeSessionBest == -1 || LapTimePrevious == PlayerLapTimeSessionBest)
+            {
+                if (OverallSessionBestLapTime == -1 || LapTimePrevious < OverallSessionBestLapTime)
                 {
-                    thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[0] - lapData.SectorTimes[1];
+                    OverallSessionBestLapTime = LapTimePrevious;
                 }
-                else if (sectorNumberJustCompleted == 2 && lapData.SectorTimes[0] > 0)
+                if (PlayerClassSessionBestLapTime == -1 || LapTimePrevious < PlayerClassSessionBestLapTime)
                 {
-                    thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[0];
+                    PlayerClassSessionBestLapTime = LapTimePrevious;
                 }
-                else if (sectorNumberJustCompleted == 1)
+            }                
+        }
+        
+
+        public void playerAddCumulativeSectorData(int sectorNumberJustCompleted, int position, float cumulativeSectorTime,
+            float gameTimeAtSectorEnd, Boolean lapIsValid, Boolean isRaining, float trackTemp, float airTemp)
+        {
+            SessionTimesAtEndOfSectors[sectorNumberJustCompleted] = gameTimeAtSectorEnd;
+            LapData lapData;
+            if (PlayerLapData.Count == 0)
+            {
+                playerStartNewLap(0, position, true, -1);
+                lapData = PlayerLapData[0];
+                lapData.hasMissingSectors = true;
+                lapData.IsValid = false;
+                lapIsValid = false;
+            }
+            else
+            {
+                lapData = PlayerLapData[PlayerLapData.Count - 1];
+            }
+            if (cumulativeSectorTime <= 0 && gameTimeAtSectorEnd > 0 && lapData.GameTimeAtLapStart > 0)
+            {
+                cumulativeSectorTime = gameTimeAtSectorEnd - lapData.GameTimeAtLapStart;
+            }
+            float thisSectorTime;
+            if (cumulativeSectorTime > 0 && sectorNumberJustCompleted == 3 && lapData.SectorTimes[0] > 0 && lapData.SectorTimes[1] > 0)
+            {
+                thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[0] - lapData.SectorTimes[1];
+            }
+            else if (cumulativeSectorTime > 0 && sectorNumberJustCompleted == 2 && lapData.SectorTimes[0] > 0)
+            {
+                thisSectorTime = cumulativeSectorTime - lapData.SectorTimes[0];
+            }
+            else if (cumulativeSectorTime > 0 && sectorNumberJustCompleted == 1)
+            {
+                thisSectorTime = cumulativeSectorTime;
+            }
+            else
+            {
+                // we don't have enough data to calculate this sector time - given that we always drop back to calculated cumulative sector
+                // times when the provided time <= 0, this should only happen if we've never actually completed a previous sector. So it's
+                // safe to assume any sector < 0 means missing data.
+                thisSectorTime = -1;
+                lapData.hasMissingSectors = true;
+                lapData.IsValid = false;
+                lapIsValid = false;
+            }
+            if (lapIsValid && thisSectorTime > 0)
+            {
+                if (sectorNumberJustCompleted == 1)
                 {
-                    thisSectorTime = cumulativeSectorTime;
-                }
-                else
-                {
-                    // we don't have enough data to calculate this sector time - given that we always drop back to calculated cumulative sector
-                    // times when the provided time <= 0, this should only happen if we've never actually completed a previous sector. So it's
-                    // safe to assume any sector < 0 means missing data.
-                    thisSectorTime = -1;
-                    lapData.hasMissingSectors = true;
-                }
-                if (lapIsValid && thisSectorTime > 0)
-                {
-                    if(sectorNumberJustCompleted == 1)
-                    {
-                        LastSector1Time = thisSectorTime;
-                    }
-                    if (sectorNumberJustCompleted == 2)
-                    {
-                        LastSector2Time = thisSectorTime;
-                    }
-                    if (sectorNumberJustCompleted == 3)
-                    {
-                        LastSector3Time = thisSectorTime;
-                    }
-                    if (sectorNumberJustCompleted == 1 && (PlayerBestSector1Time == -1 || thisSectorTime < PlayerBestSector1Time))
+                    LastSector1Time = thisSectorTime;
+                    if (PlayerBestSector1Time == -1 || thisSectorTime < PlayerBestSector1Time)
                     {
                         PlayerBestSector1Time = thisSectorTime;
                     }
-                    if (sectorNumberJustCompleted == 2 && (PlayerBestSector2Time == -1 || thisSectorTime < PlayerBestSector2Time))
+                }
+                else if (sectorNumberJustCompleted == 2)
+                {
+                    LastSector2Time = thisSectorTime;
+                    if (PlayerBestSector2Time == -1 || thisSectorTime < PlayerBestSector2Time)
                     {
                         PlayerBestSector2Time = thisSectorTime;
                     }
-                    if (sectorNumberJustCompleted == 3 && (PlayerBestSector3Time == -1 || thisSectorTime < PlayerBestSector3Time))
+                }
+                else if (sectorNumberJustCompleted == 3)
+                {
+                    LastSector3Time = thisSectorTime;
+                    if (PlayerBestSector3Time == -1 || thisSectorTime < PlayerBestSector3Time)
                     {
                         PlayerBestSector3Time = thisSectorTime;
                     }
-                }
-                else
+                }                    
+            }
+            else
+            {
+                if (sectorNumberJustCompleted == 1)
                 {
-                    if (sectorNumberJustCompleted == 1)
-                    {
-                        LastSector1Time = -1;
-                    }
-                    if (sectorNumberJustCompleted == 2)
-                    {
-                        LastSector2Time = -1;
-                    }
-                    if (sectorNumberJustCompleted == 3)
-                    {
-                        LastSector3Time = -1;
-                    }
+                    LastSector1Time = -1;
                 }
-                lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
-                lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
-                lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
-                lapData.Conditions[sectorNumberJustCompleted - 1] = new LapConditions(isRaining, trackTemp, airTemp);
-                if (lapData.IsValid && !lapIsValid)
+                else if (sectorNumberJustCompleted == 2)
                 {
-                    lapData.IsValid = false;
+                    LastSector2Time = -1;
+                }
+                else if (sectorNumberJustCompleted == 3)
+                {
+                    LastSector3Time = -1;
                 }
             }
+            lapData.SectorTimes[sectorNumberJustCompleted - 1] = thisSectorTime;
+            lapData.SectorPositions[sectorNumberJustCompleted - 1] = position;
+            lapData.GameTimeAtSectorEnd[sectorNumberJustCompleted - 1] = gameTimeAtSectorEnd;
+            lapData.Conditions[sectorNumberJustCompleted - 1] = new LapConditions(isRaining, trackTemp, airTemp);
+            if (lapData.IsValid && !lapIsValid)
+            {
+                lapData.IsValid = false;
+            }
+            
         }
 
         public float[] getPlayerTimeAndSectorsForBestLap(bool ignoreLast)
@@ -2432,7 +2461,9 @@ namespace CrewChiefV4.GameState
                     this.GameTimeWhenLastCrossedStartFinishLine = previousGameState.GameTimeWhenLastCrossedStartFinishLine;
                 }
                 // if we're waiting, see if the timer has expired or we have a change in the previous laptime value
-                if (this.WaitingForNewLapData && (previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime || this.Now > this.NewLapDataTimerExpiry) || previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime)
+                if (this.WaitingForNewLapData && 
+                    ((previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime || this.Now > this.NewLapDataTimerExpiry) || 
+                        previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime))
                 {
                     // the timer has expired or we have new data
                     this.WaitingForNewLapData = false;

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -2462,8 +2462,7 @@ namespace CrewChiefV4.GameState
                 }
                 // if we're waiting, see if the timer has expired or we have a change in the previous laptime value
                 if (this.WaitingForNewLapData && 
-                    ((previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime || this.Now > this.NewLapDataTimerExpiry) || 
-                        previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime))
+                    (previousGameState.SessionData.LapTimePrevious != gameProvidedLastLapTime || this.Now > this.NewLapDataTimerExpiry))
                 {
                     // the timer has expired or we have new data
                     this.WaitingForNewLapData = false;

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -360,7 +360,7 @@ namespace CrewChiefV4.GameState
         public int LapsDeltaBehind = -1;
 
         // 0 means we don't know what sector we're in. This is 1-indexed
-        public int SectorNumber = 1;
+        public int SectorNumber = 0;
 
         public Boolean IsNewSector = false;
 

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -494,7 +494,7 @@ namespace CrewChiefV4.GameState
             CurrentLapIsValid = true;
             formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(providedLapTime).ToString(@"mm\:ss\.fff"));
             PositionAtStartOfCurrentLap = overallPosition;
-            LapData lapData = lapData = PlayerLapData[PlayerLapData.Count - 1];
+            LapData lapData = PlayerLapData[PlayerLapData.Count - 1];
             
             LapTimePreviousEstimateForInvalidLap = SessionRunningTime - SessionTimesAtEndOfSectors[numberOfSectors - 1];
             LapTimePrevious = providedLapTime;

--- a/CrewChiefV4/PCars/PCarsGameStateMapper.cs
+++ b/CrewChiefV4/PCars/PCarsGameStateMapper.cs
@@ -962,23 +962,33 @@ namespace CrewChiefV4.PCars
 
             currentGameState.sortClassPositions();
             currentGameState.setPracOrQualiDeltas();
-            
+
             if (currentGameState.PitData.InPitlane)
             {
-                // should we just use the sector number to check this?
-                if (shared.mPitMode == (int)ePitMode.PIT_MODE_DRIVING_INTO_PITS)
+                if (previousGameState != null && !previousGameState.PitData.InPitlane)
                 {
+                    if (currentGameState.SessionData.SessionRunningTime > 30 && currentGameState.SessionData.SessionType == SessionType.Race)
+                    {
+                        currentGameState.PitData.NumPitStops++;
+                    }
                     currentGameState.PitData.OnInLap = true;
                     currentGameState.PitData.OnOutLap = false;
                 }
-                else if (shared.mPitMode == (int)ePitMode.PIT_MODE_DRIVING_OUT_OF_PITS || shared.mPitMode == (int)ePitMode.PIT_MODE_IN_GARAGE)
+                else if (currentGameState.SessionData.IsNewLap)
                 {
                     currentGameState.PitData.OnInLap = false;
                     currentGameState.PitData.OnOutLap = true;
                 }
             }
+            else if (previousGameState != null && previousGameState.PitData.InPitlane)
+            {
+                currentGameState.PitData.OnInLap = false;
+                currentGameState.PitData.OnOutLap = true;
+                currentGameState.PitData.IsAtPitExit = true;
+            }
             else if (currentGameState.SessionData.IsNewLap)
             {
+                // starting a new lap while not in the pitlane so clear the in / out lap flags
                 currentGameState.PitData.OnInLap = false;
                 currentGameState.PitData.OnOutLap = false;
             }

--- a/CrewChiefV4/PCars/PCarsGameStateMapper.cs
+++ b/CrewChiefV4/PCars/PCarsGameStateMapper.cs
@@ -716,64 +716,9 @@ namespace CrewChiefV4.PCars
             {
                 currentGameState.SessionData.CurrentLapIsValid = false;
             }
-            if (currentGameState.SessionData.IsNewSector)
-            {
-                if (currentGameState.SessionData.SectorNumber == 1)
-                {
-                    currentGameState.SessionData.LapTimePreviousEstimateForInvalidLap = currentGameState.SessionData.SessionRunningTime - currentGameState.SessionData.SessionTimesAtEndOfSectors[3];
-                    currentGameState.SessionData.SessionTimesAtEndOfSectors[3] = currentGameState.SessionData.SessionRunningTime;
-
-                    if (shared.mLastLapTime > 0 && currentGameState.SessionData.LastSector1Time > 0 && currentGameState.SessionData.LastSector2Time > 0)
-                    {
-                        currentGameState.SessionData.LastSector3Time = (shared.mLastLapTime - currentGameState.SessionData.LastSector1Time) - currentGameState.SessionData.LastSector2Time;
-                    }
-                    else
-                    {
-                        currentGameState.SessionData.LastSector3Time = -1;
-                    }
-                    if (currentGameState.SessionData.LastSector3Time > 0 && 
-                        (currentGameState.SessionData.PlayerBestSector3Time == -1 || currentGameState.SessionData.LastSector3Time < currentGameState.SessionData.PlayerBestSector3Time))
-                    {
-                        currentGameState.SessionData.PlayerBestSector3Time = currentGameState.SessionData.LastSector3Time;
-                    }
-                    if (shared.mLastLapTime > 0 &&
-                        (currentGameState.SessionData.PlayerLapTimeSessionBest == -1 || shared.mLastLapTime <= currentGameState.SessionData.PlayerLapTimeSessionBest))
-                    {
-                        currentGameState.SessionData.PlayerBestLapSector1Time = currentGameState.SessionData.LastSector1Time;
-                        currentGameState.SessionData.PlayerBestLapSector2Time = currentGameState.SessionData.LastSector2Time;
-                        currentGameState.SessionData.PlayerBestLapSector3Time = currentGameState.SessionData.LastSector3Time;
-                    }
-                }
-                else if (currentGameState.SessionData.SectorNumber == 2)
-                {
-                    currentGameState.SessionData.SessionTimesAtEndOfSectors[1] = currentGameState.SessionData.SessionRunningTime;
-                    // TODO: confirm that an invalid sector will put -1 in here...
-                    currentGameState.SessionData.LastSector1Time = shared.mCurrentSector1Time;
-                    if (currentGameState.SessionData.LastSector1Time > 0 && !shared.mLapInvalidated &&
-                        (currentGameState.SessionData.PlayerBestSector1Time == -1 || currentGameState.SessionData.LastSector1Time < currentGameState.SessionData.PlayerBestSector1Time))
-                    {
-                        currentGameState.SessionData.PlayerBestSector1Time = currentGameState.SessionData.LastSector1Time;
-                    }
-                    currentGameState.SessionData.playerAddCumulativeSectorData(1, currentGameState.SessionData.OverallPosition, shared.mCurrentSector1Time,
-                        currentGameState.SessionData.SessionRunningTime, !shared.mLapInvalidated, shared.mRainDensity > 0, shared.mTrackTemperature, shared.mAmbientTemperature);
-                }
-                if (currentGameState.SessionData.SectorNumber == 3)
-                {
-                    currentGameState.SessionData.SessionTimesAtEndOfSectors[2] = currentGameState.SessionData.SessionRunningTime;
-                    currentGameState.SessionData.LastSector2Time = shared.mCurrentSector2Time;
-                    if (currentGameState.SessionData.LastSector2Time > 0 && !shared.mLapInvalidated &&
-                        (currentGameState.SessionData.PlayerBestSector2Time == -1 || currentGameState.SessionData.LastSector2Time < currentGameState.SessionData.PlayerBestSector2Time))
-                    {
-                        currentGameState.SessionData.PlayerBestSector2Time = currentGameState.SessionData.LastSector2Time;
-                    }
-                    currentGameState.SessionData.playerAddCumulativeSectorData(2, currentGameState.SessionData.OverallPosition, shared.mCurrentSector2Time + shared.mCurrentSector1Time,
-                        currentGameState.SessionData.SessionRunningTime, !shared.mLapInvalidated, shared.mRainDensity > 0, shared.mTrackTemperature, shared.mAmbientTemperature);
-                }
-            }
-
+            
             currentGameState.SessionData.Flag = mapToFlagEnum(shared.mHighestFlagColour);
-            currentGameState.SessionData.NumCarsOverall = shared.mNumParticipants;
-            currentGameState.SessionData.CurrentLapIsValid = !shared.mLapInvalidated;                
+            currentGameState.SessionData.NumCarsOverall = shared.mNumParticipants;            
             currentGameState.SessionData.IsNewLap = previousGameState == null || currentGameState.SessionData.CompletedLaps == previousGameState.SessionData.CompletedLaps + 1 ||
                 ((shared.mSessionState == (int)eSessionState.SESSION_PRACTICE || shared.mSessionState == (int)eSessionState.SESSION_QUALIFY || 
                 shared.mSessionState == (int)eSessionState.SESSION_TEST || shared.mSessionState == (int)eSessionState.SESSION_TIME_ATTACK) 
@@ -800,6 +745,29 @@ namespace CrewChiefV4.PCars
                 }
             }
             currentGameState.SessionData.LapTimeCurrent = shared.mCurrentTime;
+            currentGameState.SessionData.LapTimePrevious = shared.mLastLapTime;
+            if (currentGameState.SessionData.IsNewLap)
+            {
+                currentGameState.SessionData.playerCompleteLapWithProvidedLapTime(currentGameState.SessionData.OverallPosition, currentGameState.SessionData.SessionRunningTime,
+                        shared.mLastLapTime, currentGameState.SessionData.CurrentLapIsValid, currentGameState.PitData.InPitlane,
+                        shared.mRainDensity == 1, shared.mTrackTemperature, shared.mAmbientTemperature,
+                        currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining, 3);
+                currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1,
+                    currentGameState.SessionData.OverallPosition, currentGameState.PitData.InPitlane, currentGameState.SessionData.SessionRunningTime);
+            }
+            else if (currentGameState.SessionData.IsNewSector)
+            {
+                if (currentGameState.SessionData.SectorNumber == 2)
+                {
+                    currentGameState.SessionData.playerAddCumulativeSectorData(1, currentGameState.SessionData.OverallPosition, shared.mCurrentSector1Time,
+                        currentGameState.SessionData.SessionRunningTime, currentGameState.SessionData.CurrentLapIsValid, shared.mRainDensity > 0, shared.mTrackTemperature, shared.mAmbientTemperature);
+                }
+                else if (currentGameState.SessionData.SectorNumber == 3)
+                {
+                    currentGameState.SessionData.playerAddCumulativeSectorData(2, currentGameState.SessionData.OverallPosition, shared.mCurrentSector2Time + shared.mCurrentSector1Time,
+                        currentGameState.SessionData.SessionRunningTime, currentGameState.SessionData.CurrentLapIsValid, shared.mRainDensity > 0, shared.mTrackTemperature, shared.mAmbientTemperature);
+                }
+            }
 
             // NOTE: the shared.mSessionFastestLapTime is JUST FOR THE PLAYER so the code below is not going to work:
             // currentGameState.SessionData.SessionFastestLapTimeFromGame = shared.mSessionFastestLapTime;
@@ -994,45 +962,7 @@ namespace CrewChiefV4.PCars
 
             currentGameState.sortClassPositions();
             currentGameState.setPracOrQualiDeltas();
-
-            currentGameState.SessionData.LapTimePrevious = shared.mLastLapTime;
-            if (currentGameState.SessionData.IsNewLap)
-            {
-                currentGameState.SessionData.PreviousLapWasValid = previousGameState != null && previousGameState.SessionData.CurrentLapIsValid;
-                currentGameState.SessionData.CurrentLapIsValid = true;
-                currentGameState.SessionData.formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(shared.mLastLapTime).ToString(@"mm\:ss\.fff"));
-                currentGameState.SessionData.PositionAtStartOfCurrentLap = currentGameState.SessionData.OverallPosition;
-                currentGameState.SessionData.playerCompleteLapWithProvidedLapTime(currentGameState.SessionData.OverallPosition, currentGameState.SessionData.SessionRunningTime,
-                        shared.mLastLapTime, currentGameState.SessionData.PreviousLapWasValid, currentGameState.PitData.InPitlane, false, shared.mTrackTemperature, shared.mAmbientTemperature, 
-                        currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining, 3);
-                currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1,
-                    currentGameState.SessionData.OverallPosition, currentGameState.PitData.InPitlane, currentGameState.SessionData.SessionRunningTime);
-            }
-            else if (previousGameState != null)
-            {
-                currentGameState.SessionData.PreviousLapWasValid = previousGameState.SessionData.PreviousLapWasValid;
-            }
-
-            if (currentGameState.SessionData.IsNewLap && currentGameState.SessionData.PreviousLapWasValid &&
-                currentGameState.SessionData.LapTimePrevious > 0)
-            {
-                if (currentGameState.SessionData.PlayerLapTimeSessionBest == -1 ||
-                     currentGameState.SessionData.LapTimePrevious < currentGameState.SessionData.PlayerLapTimeSessionBest)
-                {
-                    currentGameState.SessionData.PlayerLapTimeSessionBest = currentGameState.SessionData.LapTimePrevious;
-                    if (currentGameState.SessionData.OverallSessionBestLapTime == -1 ||
-                        currentGameState.SessionData.LapTimePrevious < currentGameState.SessionData.OverallSessionBestLapTime)
-                    {
-                        currentGameState.SessionData.OverallSessionBestLapTime = currentGameState.SessionData.LapTimePrevious;
-                    }
-                    if (currentGameState.SessionData.PlayerClassSessionBestLapTime == -1 ||
-                        currentGameState.SessionData.LapTimePrevious < currentGameState.SessionData.PlayerClassSessionBestLapTime)
-                    {
-                        currentGameState.SessionData.PlayerClassSessionBestLapTime = currentGameState.SessionData.LapTimePrevious;
-                    }
-                }
-            }
-
+            
             if (currentGameState.PitData.InPitlane)
             {
                 // should we just use the sector number to check this?

--- a/CrewChiefV4/PCars/PCarsGameStateMapper.cs
+++ b/CrewChiefV4/PCars/PCarsGameStateMapper.cs
@@ -1006,8 +1006,7 @@ namespace CrewChiefV4.PCars
                         shared.mLastLapTime, currentGameState.SessionData.PreviousLapWasValid, currentGameState.PitData.InPitlane, false, shared.mTrackTemperature, shared.mAmbientTemperature, 
                         currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining, 3);
                 currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1,
-                    currentGameState.SessionData.OverallPosition, currentGameState.PitData.InPitlane, currentGameState.SessionData.SessionRunningTime, false, 
-                    shared.mTrackTemperature, shared.mAmbientTemperature);
+                    currentGameState.SessionData.OverallPosition, currentGameState.PitData.InPitlane, currentGameState.SessionData.SessionRunningTime);
             }
             else if (previousGameState != null)
             {

--- a/CrewChiefV4/PCars2/PCars2GameStateMapper.cs
+++ b/CrewChiefV4/PCars2/PCars2GameStateMapper.cs
@@ -610,7 +610,6 @@ namespace CrewChiefV4.PCars2
                 pitMode == ePitMode.PIT_MODE_DRIVING_OUT_OF_PITS ||
                 pitMode == ePitMode.PIT_MODE_IN_GARAGE ||
                 pitMode == ePitMode.PIT_MODE_DRIVING_OUT_OF_GARAGE;
-
             if (shared.mLapInvalidated)
             {
                 if (currentGameState.SessionData.CurrentLapIsValid && currentGameState.SessionData.CompletedLaps > 0)

--- a/CrewChiefV4/PCars2/PCars2GameStateMapper.cs
+++ b/CrewChiefV4/PCars2/PCars2GameStateMapper.cs
@@ -724,7 +724,6 @@ namespace CrewChiefV4.PCars2
                             currentGameState.OpponentData.Remove(participantName);
                             continue;
                         }
-                        CarData.CarClass opponentCarClass = CarData.getCarClassForClassName(StructHelper.getCarClassName(shared, i));
 
                         OpponentData currentOpponentData = null;
                         if (currentGameState.OpponentData.TryGetValue(participantName, out currentOpponentData))
@@ -796,7 +795,7 @@ namespace CrewChiefV4.PCars2
                                             new float[] { participantStruct.mWorldPosition[0], participantStruct.mWorldPosition[2] }, previousOpponentWorldPosition,
                                             shared.mSpeeds[i], shared.mWorldFastestLapTime, shared.mWorldFastestSector1Time, shared.mWorldFastestSector2Time, shared.mWorldFastestSector3Time, 
                                             participantStruct.mCurrentLapDistance, shared.mRainDensity == 1,
-                                            shared.mAmbientTemperature, shared.mTrackTemperature, opponentCarClass,
+                                            shared.mAmbientTemperature, shared.mTrackTemperature,
                                             currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining,
                                             lastSectorTime, shared.mLapsInvalidated[i] == 1, currentGameState.SessionData.TrackDefinition.distanceForNearPitEntryChecks);
 
@@ -815,6 +814,7 @@ namespace CrewChiefV4.PCars2
                                     if (currentOpponentData.IsNewLap)
                                     {
                                         currentOpponentData.trackLandmarksTiming.cancelWaitingForLandmarkEnd();
+                                        currentOpponentData.CarClass = CarData.getCarClassForClassName(StructHelper.getCarClassName(shared, i));
                                     }
                                     if (currentOpponentData.IsNewLap && currentOpponentData.CurrentBestLapTime > 0)
                                     {
@@ -856,7 +856,7 @@ namespace CrewChiefV4.PCars2
                         {
                             if (participantStruct.mIsActive && participantName != null && participantName.Length > 0)
                             {
-                                addOpponentForName(participantName, createOpponentData(participantStruct, true, opponentCarClass,
+                                addOpponentForName(participantName, createOpponentData(participantStruct, true, CarData.getCarClassForClassName(StructHelper.getCarClassName(shared, i)),
                                     participantStruct.mName != null && participantStruct.mName[0] != 0, currentGameState.SessionData.TrackDefinition.trackLength), currentGameState);
                             }
                         }
@@ -1301,7 +1301,7 @@ namespace CrewChiefV4.PCars2
             Boolean isInPits, Boolean isLeavingPits,
             float sessionRunningTime, float secondsSinceLastUpdate, float[] currentWorldPosition, float[] previousWorldPosition,
             float speed, float worldRecordLapTime, float worldRecordS1Time, float worldRecordS2Time, float worldRecordS3Time, 
-            float distanceRoundTrack, Boolean isRaining, float trackTemp, float airTemp, CarData.CarClass carClass,
+            float distanceRoundTrack, Boolean isRaining, float trackTemp, float airTemp, 
             Boolean sessionLengthIsTime, float sessionTimeRemaining, float lastSectorTime, Boolean lapInvalidated, float nearPitEntryPointDistance)
         {
             float previousDistanceRoundTrack = opponentData.DistanceRoundTrack;
@@ -1315,7 +1315,6 @@ namespace CrewChiefV4.PCars2
             }
             opponentData.WorldPosition = currentWorldPosition;
             opponentData.IsNewLap = false;
-            opponentData.CarClass = carClass;
             opponentData.JustEnteredPits = !opponentData.InPits && (isInPits || isEnteringPits);
             if (opponentData.JustEnteredPits)
             {

--- a/CrewChiefV4/PCars2/PCars2GameStateMapper.cs
+++ b/CrewChiefV4/PCars2/PCars2GameStateMapper.cs
@@ -892,6 +892,10 @@ namespace CrewChiefV4.PCars2
             {
                 if (previousGameState != null && !previousGameState.PitData.InPitlane)
                 {
+                    if (currentGameState.SessionData.SessionRunningTime > 30 && currentGameState.SessionData.SessionType == SessionType.Race)
+                    {
+                        currentGameState.PitData.NumPitStops++;
+                    }
                     currentGameState.PitData.OnInLap = true;
                     currentGameState.PitData.OnOutLap = false;
                 }
@@ -901,19 +905,18 @@ namespace CrewChiefV4.PCars2
                     currentGameState.PitData.OnOutLap = true;
                 }
             }
-            else if (previousGameState == null || previousGameState.PitData.InPitlane)
+            else if (previousGameState != null && previousGameState.PitData.InPitlane)
             {
-                currentGameState.PitData.OnOutLap = true;
                 currentGameState.PitData.OnInLap = false;
+                currentGameState.PitData.OnOutLap = true;
+                currentGameState.PitData.IsAtPitExit = true;
             }
             else if (currentGameState.SessionData.IsNewLap)
             {
+                // starting a new lap while not in the pitlane so clear the in / out lap flags
                 currentGameState.PitData.OnInLap = false;
                 currentGameState.PitData.OnOutLap = false;
             }
-
-            currentGameState.PitData.IsAtPitExit = previousGameState != null && currentGameState.PitData.OnOutLap && 
-                previousGameState.PitData.InPitlane && !currentGameState.PitData.InPitlane;
 
             ePitSchedule pitShedule = (ePitSchedule)shared.mPitSchedule;
             if (pitShedule == ePitSchedule.PIT_SCHEDULE_NONE)

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -688,7 +688,6 @@ namespace CrewChiefV4.RaceRoom
 
                     if (currentGameState.PitData.InPitlane)
                     {
-                        // the track sector number is nonsense when we're on an out lap
                         if (previousGameState != null && !previousGameState.PitData.InPitlane)
                         {
                             if (currentGameState.SessionData.SessionRunningTime > 30 && currentGameState.SessionData.SessionType == SessionType.Race)
@@ -698,20 +697,23 @@ namespace CrewChiefV4.RaceRoom
                             currentGameState.PitData.OnInLap = true;
                             currentGameState.PitData.OnOutLap = false;
                         }
+                        else if (currentGameState.SessionData.IsNewLap)
+                        {
+                            currentGameState.PitData.OnInLap = false;
+                            currentGameState.PitData.OnOutLap = true;
+                        }
                     }
                     else if (previousGameState != null && previousGameState.PitData.InPitlane)
                     {
                         currentGameState.PitData.OnInLap = false;
                         currentGameState.PitData.OnOutLap = true;
-                        currentGameState.SessionData.PreviousLapWasValid = false;
-                        currentGameState.SessionData.CurrentLapIsValid = false;
                         currentGameState.PitData.IsAtPitExit = true;
                     }
                     else if (currentGameState.SessionData.IsNewLap)
                     {
                         // starting a new lap while not in the pitlane so clear the in / out lap flags
                         currentGameState.PitData.OnInLap = false;
-                        currentGameState.PitData.OnOutLap = false;                        
+                        currentGameState.PitData.OnOutLap = false;
                     }
                     break;
                 }

--- a/CrewChiefV4/R3E/R3EGameStateMapper.cs
+++ b/CrewChiefV4/R3E/R3EGameStateMapper.cs
@@ -637,7 +637,6 @@ namespace CrewChiefV4.RaceRoom
                             brakeTempThresholdsForPlayersCar = CarData.getBrakeTempThresholds(currentGameState.carClass);
                         }
                     }
-
                     if (currentGameState.SessionData.CurrentLapIsValid && (participantStruct.CurrentLapValid != 1 || participantStruct.LapTimeCurrentSelf == -1))
                     {
                         currentGameState.SessionData.CurrentLapIsValid = false;

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -389,7 +389,7 @@ namespace CrewChiefV4.rFactor1
             {
                 currentGameState.SessionData.playerCompleteLapWithProvidedLapTime(currentGameState.SessionData.OverallPosition, currentGameState.SessionData.SessionRunningTime,
                         lastSectorTime, lastSectorTime > 0, player.inPits == 1, false, shared.trackTemp, shared.ambientTemp, currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining, 3);
-                currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1, currentGameState.SessionData.OverallPosition, player.inPits == 1 || player.lapDist < 0, currentGameState.SessionData.SessionRunningTime, false, shared.trackTemp, shared.ambientTemp);
+                currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1, currentGameState.SessionData.OverallPosition, player.inPits == 1 || player.lapDist < 0, currentGameState.SessionData.SessionRunningTime);
             }
             else if (currentGameState.SessionData.IsNewSector)
             {

--- a/CrewChiefV4/RF1/RF1GameStateMapper.cs
+++ b/CrewChiefV4/RF1/RF1GameStateMapper.cs
@@ -423,10 +423,6 @@ namespace CrewChiefV4.rFactor1
                     currentGameState.SessionData.formattedPlayerLapTimes.Add(lt);
                 }
             }
-            if (currentGameState.SessionData.IsNewLap && currentGameState.SessionData.LapTimePrevious > 0)
-            {
-                currentGameState.SessionData.formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(currentGameState.SessionData.LapTimePrevious).ToString(@"mm\:ss\.fff"));
-            }
             currentGameState.SessionData.LeaderHasFinishedRace = leader.finishStatus == (int)rFactor1Constant.rfFinishStatus.finished;
             currentGameState.SessionData.LeaderSectorNumber = leader.sector == 0 ? 3 : leader.sector;
             currentGameState.SessionData.TimeDeltaFront = Math.Abs(player.timeBehindNext);

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -897,9 +897,6 @@ namespace CrewChiefV4.rFactor2
                     csd.formattedPlayerLapTimes.Add(lt);
             }
 
-            if (csd.IsNewLap && csd.LapTimePrevious > 0)
-                csd.formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(csd.LapTimePrevious).ToString(@"mm\:ss\.fff"));
-
             csd.LeaderHasFinishedRace = leaderScoring.mFinishStatus == (int)rFactor2Constants.rF2FinishStatus.Finished;
             csd.LeaderSectorNumber = leaderScoring.mSector == 0 ? 3 : leaderScoring.mSector;
             csd.TimeDeltaFront = (float)Math.Abs(playerScoring.mTimeBehindNext);

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -127,6 +127,7 @@ namespace CrewChiefV4.rFactor2
         public static bool pluginVerified = false;
         public override void versionCheck(Object memoryMappedFileStruct)
         {
+            /*
             if (RF2GameStateMapper.pluginVerified)
                 return;
 
@@ -176,7 +177,7 @@ namespace CrewChiefV4.rFactor2
                 var msg = "rFactor 2 Shared Memory version: " + versionStr + " 64bit."
                     + (shared.extended.mHostedPluginVars.StockCarRules_IsHosted != 0 ? ("  Stock Car Rules plugin hosted. (DFT:" + shared.extended.mHostedPluginVars.StockCarRules_DoubleFileType + ")")  : "");
                 Console.WriteLine(msg);
-            }
+            }*/
         }
         
         // Abrupt session detection variables.

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -1972,10 +1972,7 @@ namespace CrewChiefV4.rFactor2
                     csd.CompletedLaps + 1,
                     csd.OverallPosition,
                     playerScoring.mInPits == 1 || currentGameState.PositionAndMotionData.DistanceRoundTrack < 0.0f,
-                    csd.SessionRunningTime,
-                    scoring.mScoringInfo.mRaining > minRainThreshold,
-                    (float)scoring.mScoringInfo.mTrackTemp,
-                    (float)scoring.mScoringInfo.mAmbientTemp);
+                    csd.SessionRunningTime);
             }
             else if (csd.IsNewSector && lastSectorTime > 0.0f)
             {

--- a/CrewChiefV4/RF2/RF2GameStateMapper.cs
+++ b/CrewChiefV4/RF2/RF2GameStateMapper.cs
@@ -127,7 +127,6 @@ namespace CrewChiefV4.rFactor2
         public static bool pluginVerified = false;
         public override void versionCheck(Object memoryMappedFileStruct)
         {
-            /*
             if (RF2GameStateMapper.pluginVerified)
                 return;
 
@@ -177,7 +176,7 @@ namespace CrewChiefV4.rFactor2
                 var msg = "rFactor 2 Shared Memory version: " + versionStr + " 64bit."
                     + (shared.extended.mHostedPluginVars.StockCarRules_IsHosted != 0 ? ("  Stock Car Rules plugin hosted. (DFT:" + shared.extended.mHostedPluginVars.StockCarRules_DoubleFileType + ")")  : "");
                 Console.WriteLine(msg);
-            }*/
+            }
         }
         
         // Abrupt session detection variables.

--- a/CrewChiefV4/iRacing/iRacingGameStateMapper.cs
+++ b/CrewChiefV4/iRacing/iRacingGameStateMapper.cs
@@ -627,8 +627,7 @@ namespace CrewChiefV4.iRacing
             if (currentGameState.SessionData.PlayerLapData.Count == 0 || currentGameState.SessionData.IsNewLap)
             {
                 currentGameState.SessionData.playerStartNewLap(currentGameState.SessionData.CompletedLaps + 1,
-                    currentGameState.SessionData.OverallPosition, currentGameState.PitData.InPitlane, playerCar.Live.GameTimeWhenLastCrossedSFLine, false,
-                    shared.Telemetry.TrackTemp, shared.Telemetry.AirTemp);
+                    currentGameState.SessionData.OverallPosition, currentGameState.PitData.InPitlane, playerCar.Live.GameTimeWhenLastCrossedSFLine);
             }
 
             currentGameState.PositionAndMotionData.DistanceRoundTrack = currentGameState.SessionData.TrackDefinition != null ? Math.Abs(currentGameState.SessionData.TrackDefinition.trackLength * playerCar.Live.CorrectedLapDistance) : -1.0f;

--- a/CrewChiefV4/iRacing/iRacingGameStateMapper.cs
+++ b/CrewChiefV4/iRacing/iRacingGameStateMapper.cs
@@ -599,10 +599,6 @@ namespace CrewChiefV4.iRacing
                 Boolean lapValid = validSpeed && playerCar.Live.PreviousLapWasValid && currentGameState.SessionData.CurrentLapIsValid && !currentGameState.PitData.JumpedToPits;
                 if (currentSector == 1 && currentGameState.SessionData.IsNewLap)
                 {
-                    currentGameState.SessionData.PositionAtStartOfCurrentLap = currentGameState.SessionData.OverallPosition;
-
-                    currentGameState.SessionData.formattedPlayerLapTimes.Add(TimeSpan.FromSeconds(playerCar.Live.LapTimePrevious).ToString(@"mm\:ss\.fff"));
-
                     currentGameState.SessionData.playerCompleteLapWithProvidedLapTime(currentGameState.SessionData.OverallPosition, currentGameState.SessionData.SessionRunningTime,
                         playerCar.Live.LapTimePrevious, lapValid, currentGameState.PitData.InPitlane, false, shared.Telemetry.TrackTemp, shared.Telemetry.AirTemp,
                         currentGameState.SessionData.SessionHasFixedTime, currentGameState.SessionData.SessionTimeRemaining, 3);


### PR DESCRIPTION
reworked pcars, pcars2, ac and r3e mappers to use timing data methods in GameStateData instead of the mess in the mappers. iRacing and RF2 haven't changed much