### PR TITLE
Prioritisation

### DIFF
--- a/CrewChiefV4/App.config
+++ b/CrewChiefV4/App.config
@@ -859,6 +859,9 @@
       <setting name="iracing_enable_auto_fuel_to_end_of_race" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="priortise_messages_depending_on_situation" serializeAs="String">
+        <value>False</value>
+      </setting>
     </CrewChiefV4.Properties.Settings>
   </userSettings>
 </configuration>

--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -1008,7 +1008,7 @@ namespace CrewChiefV4.Audio
             return channelOpen;
         }
 
-        public void playMessage(QueuedMessage queuedMessage)
+        public void playMessage(QueuedMessage queuedMessage, int priority = SoundMetadata.DEFAULT_PRIORITY)
         {
             if (GlobalBehaviourSettings.enabledMessageTypes.Contains(MessageTypes.NONE))
             {
@@ -1016,7 +1016,7 @@ namespace CrewChiefV4.Audio
             } 
             else
             {
-                playMessage(queuedMessage, PearlsOfWisdom.PearlType.NONE, 0);
+                playMessage(queuedMessage, PearlsOfWisdom.PearlType.NONE, 0, priority);
             }
         }
 
@@ -1185,7 +1185,7 @@ namespace CrewChiefV4.Audio
             return index;
         }
 
-        public void playMessage(QueuedMessage queuedMessage, PearlsOfWisdom.PearlType pearlType, double pearlMessageProbability)
+        public void playMessage(QueuedMessage queuedMessage, PearlsOfWisdom.PearlType pearlType, double pearlMessageProbability, int priority = SoundMetadata.DEFAULT_PRIORITY)
         {
             if (queuedMessage.canBePlayed)
             {
@@ -1196,33 +1196,37 @@ namespace CrewChiefV4.Audio
                         Console.WriteLine("Clip for event " + queuedMessage.messageName + " is already queued, ignoring");
                         return;
                     }
-                    else if (PlaybackModerator.MessageCanBeQueued(queuedMessage, queuedClips.Count, CrewChief.currentGameState.Now))
+                    else
                     {
                         // default 'regular' message priority is 0, which is lowest
-                        populateSoundMetadata(queuedMessage, SoundType.REGULAR_MESSAGE, 0);
-                        PearlsOfWisdom.PearlMessagePosition pearlPosition = PearlsOfWisdom.PearlMessagePosition.NONE;
-                        if (pearlType != PearlsOfWisdom.PearlType.NONE && checkPearlOfWisdomValid(pearlType))
+                        populateSoundMetadata(queuedMessage, SoundType.REGULAR_MESSAGE, priority);
+                        DateTime now = CrewChief.currentGameState == null ? DateTime.Now : CrewChief.currentGameState.Now;
+                        if (PlaybackModerator.MessageCanBeQueued(queuedMessage, queuedClips.Count, now))
                         {
-                            pearlPosition = pearlsOfWisdom.getMessagePosition(pearlMessageProbability);
-                        }
+                            PearlsOfWisdom.PearlMessagePosition pearlPosition = PearlsOfWisdom.PearlMessagePosition.NONE;
+                            if (pearlType != PearlsOfWisdom.PearlType.NONE && checkPearlOfWisdomValid(pearlType))
+                            {
+                                pearlPosition = pearlsOfWisdom.getMessagePosition(pearlMessageProbability);
+                            }
 
-                        int insertionIndex = getInsertionIndex(queuedClips, queuedMessage);
-                        if (pearlPosition == PearlsOfWisdom.PearlMessagePosition.BEFORE)
-                        {
-                            QueuedMessage pearlQueuedMessage = new QueuedMessage(queuedMessage.abstractEvent);
-                            pearlQueuedMessage.metadata = queuedMessage.metadata;
-                            pearlQueuedMessage.dueTime = queuedMessage.dueTime;
-                            queuedClips.Insert(insertionIndex, PearlsOfWisdom.getMessageFolder(pearlType), pearlQueuedMessage);
-                            insertionIndex++;
-                        }
-                        queuedClips.Insert(insertionIndex, queuedMessage.messageName, queuedMessage);
-                        if (pearlPosition == PearlsOfWisdom.PearlMessagePosition.AFTER)
-                        {
-                            QueuedMessage pearlQueuedMessage = new QueuedMessage(queuedMessage.abstractEvent);
-                            pearlQueuedMessage.dueTime = queuedMessage.dueTime;
-                            pearlQueuedMessage.metadata = queuedMessage.metadata;
-                            insertionIndex++;
-                            queuedClips.Insert(insertionIndex, PearlsOfWisdom.getMessageFolder(pearlType), pearlQueuedMessage);
+                            int insertionIndex = getInsertionIndex(queuedClips, queuedMessage);
+                            if (pearlPosition == PearlsOfWisdom.PearlMessagePosition.BEFORE)
+                            {
+                                QueuedMessage pearlQueuedMessage = new QueuedMessage(queuedMessage.abstractEvent);
+                                pearlQueuedMessage.metadata = queuedMessage.metadata;
+                                pearlQueuedMessage.dueTime = queuedMessage.dueTime;
+                                queuedClips.Insert(insertionIndex, PearlsOfWisdom.getMessageFolder(pearlType), pearlQueuedMessage);
+                                insertionIndex++;
+                            }
+                            queuedClips.Insert(insertionIndex, queuedMessage.messageName, queuedMessage);
+                            if (pearlPosition == PearlsOfWisdom.PearlMessagePosition.AFTER)
+                            {
+                                QueuedMessage pearlQueuedMessage = new QueuedMessage(queuedMessage.abstractEvent);
+                                pearlQueuedMessage.dueTime = queuedMessage.dueTime;
+                                pearlQueuedMessage.metadata = queuedMessage.metadata;
+                                insertionIndex++;
+                                queuedClips.Insert(insertionIndex, PearlsOfWisdom.getMessageFolder(pearlType), pearlQueuedMessage);
+                            }
                         }
                     }
                 }

--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -1185,7 +1185,6 @@ namespace CrewChiefV4.Audio
             return index;
         }
 
-
         public void playMessage(QueuedMessage queuedMessage, PearlsOfWisdom.PearlType pearlType, double pearlMessageProbability)
         {
             if (queuedMessage.canBePlayed)

--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -1196,7 +1196,7 @@ namespace CrewChiefV4.Audio
                         Console.WriteLine("Clip for event " + queuedMessage.messageName + " is already queued, ignoring");
                         return;
                     }
-                    else
+                    else if (PlaybackModerator.MessageCanBeQueued(queuedMessage, queuedClips.Count, CrewChief.currentGameState.Now))
                     {
                         // default 'regular' message priority is 0, which is lowest
                         populateSoundMetadata(queuedMessage, SoundType.REGULAR_MESSAGE, 0);

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -103,7 +103,7 @@ namespace CrewChiefV4.Audio
                     }
                     else if (currentGameState.SessionData.CompletedLaps == 0 ||
                         (!currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.CompletedLaps + 1 >= currentGameState.SessionData.SessionNumberOfLaps) ||
-                        (currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.SessionRunningTime + 2 >= currentGameState.SessionData.SessionTotalRunTime))
+                        (currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.SessionRunningTime + 120 >= currentGameState.SessionData.SessionTotalRunTime))
                     {
                         verbosity = Verbosity.MED;
                     }

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -66,8 +66,7 @@ namespace CrewChiefV4.Audio
         private static Dictionary<Verbosity, int> minPriorityForEachVerbosity = new Dictionary<Verbosity, int>() {
             {Verbosity.FULL, 0},
             {Verbosity.MED, 5},
-            {Verbosity.LOW, 10},
-            {Verbosity.SILENT, 20}  // this one isn't used. Remove it?
+            {Verbosity.LOW, 10}
         };
 
         public static void clearVerbosityData()

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -67,7 +67,7 @@ namespace CrewChiefV4.Audio
             {Verbosity.FULL, 0},
             {Verbosity.MED, 5},
             {Verbosity.LOW, 10},
-            {Verbosity.SILENT, 20}
+            {Verbosity.SILENT, 20}  // this one isn't used. Remove it?
         };
 
         public static void clearVerbosityData()

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -59,7 +59,7 @@ namespace CrewChiefV4.Audio
 
         public static int lastBlockedMessageId = -1;
 
-        public static Verbosity verbosity = Verbosity.FULL;
+        private static Verbosity verbosity = Verbosity.FULL;
         private static Dictionary<String, MessageQueueCounter> queuedMessageCounters = new Dictionary<string,MessageQueueCounter>();
         private static DateTime nextVerbosityUpdate = DateTime.MinValue;
 
@@ -70,9 +70,11 @@ namespace CrewChiefV4.Audio
             {Verbosity.SILENT, 20}
         };
 
-        public static void clearPlayedMessageCounters()
+        public static void clearVerbosityData()
         {
             queuedMessageCounters.Clear();
+            verbosity = Verbosity.FULL;
+            nextVerbosityUpdate = DateTime.MinValue;
         }
 
         public static void UpdateAutoVerbosity(GameStateData currentGameState)

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -87,17 +87,24 @@ namespace CrewChiefV4.Audio
                 return;
             }
             nextVerbosityUpdate = currentGameState.Now.AddSeconds(1);
-            if (currentGameState.SessionData.SessionType == SessionType.Race && currentGameState.PositionAndMotionData.CarSpeed > 5)
+            verbosity = Verbosity.FULL;
+            if (currentGameState.PositionAndMotionData.CarSpeed > 5)
             {
-                // only interested if we're moving and it's a race session
-                if ((currentGameState.SessionData.TimeDeltaFront < 3 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
-                    currentGameState.SessionData.TimeDeltaFront < 2 || currentGameState.SessionData.TimeDeltaBehind < 2)
+                if (currentGameState.SessionData.SessionType == SessionType.Race)
                 {
-                    verbosity = Verbosity.LOW;
+                    if ((currentGameState.SessionData.TimeDeltaFront < 3 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
+                        currentGameState.SessionData.TimeDeltaFront < 2 || currentGameState.SessionData.TimeDeltaBehind < 2)
+                    {
+                        verbosity = Verbosity.LOW;
+                    }
+                    else if (currentGameState.SessionData.CompletedLaps == 0 ||
+                        (!currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.CompletedLaps + 1 >= currentGameState.SessionData.SessionNumberOfLaps) ||
+                        (currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.SessionRunningTime + 2 >= currentGameState.SessionData.SessionTotalRunTime))
+                    {
+                        verbosity = Verbosity.MED;
+                    }
                 }
-                else if (currentGameState.SessionData.CompletedLaps == 0 || 
-                    (!currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.CompletedLaps + 1 >= currentGameState.SessionData.SessionNumberOfLaps) ||
-                    (currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.SessionRunningTime + 2 >= currentGameState.SessionData.SessionTotalRunTime))
+                else if (currentGameState.SessionData.SessionType == SessionType.Qualify && !currentGameState.PitData.OnOutLap && currentGameState.SessionData.CurrentLapIsValid)
                 {
                     verbosity = Verbosity.MED;
                 }

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -93,12 +93,23 @@ namespace CrewChiefV4.Audio
             {
                 if (currentGameState.SessionData.SessionType == SessionType.Race)
                 {
-                    if ((currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 3 && 
-                         currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
-                        (currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 2) ||
-                        (currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 2))
+                    Boolean inCloseTraffic = currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 1.5 &&
+                         currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 1.5;
+                    Boolean hasCarVeryClose = (currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 1) ||
+                        (currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 1);
+                    
+                    Boolean inTraffic = currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 3 &&
+                         currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 3;                   
+                    Boolean hasCarClose = (currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 2) ||
+                        (currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 2);
+
+                    if (inCloseTraffic || hasCarVeryClose)
                     {
                         verbosity = Verbosity.LOW;
+                    }
+                    else if (inTraffic || hasCarClose)
+                    {
+                        verbosity = Verbosity.MED;
                     }
                     else if (currentGameState.SessionData.CompletedLaps == 0 ||
                         (!currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.CompletedLaps + 1 >= currentGameState.SessionData.SessionNumberOfLaps) ||

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -66,7 +66,8 @@ namespace CrewChiefV4.Audio
         private static Dictionary<Verbosity, int> minPriorityForEachVerbosity = new Dictionary<Verbosity, int>() {
             {Verbosity.FULL, 0},
             {Verbosity.MED, 5},
-            {Verbosity.LOW, 10}
+            {Verbosity.LOW, 10},
+            {Verbosity.SILENT, 20}
         };
 
         public static void clearVerbosityData()

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -315,7 +315,7 @@ namespace CrewChiefV4.Audio
             }
             else
             {
-                PlaybackModerator.Trace(string.Format("Message {} hasn't been queued because its priority is {} and our verbosity is currently {}", queuedMessage.messageName, priority, verbosity));
+                PlaybackModerator.Trace(string.Format("Message {0} hasn't been queued because its priority is {1} and our verbosity is currently {2}", queuedMessage.messageName, priority, verbosity));
             }
             return canPlay;
         }

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -49,6 +49,7 @@ namespace CrewChiefV4.Audio
         private static bool insertBeepInBetweenSpotterAndChief = UserSettings.GetUserSettings().getBoolean("insert_beep_in_between_spotter_and_chief");
         private static bool rejectMessagesWhenTalking = UserSettings.GetUserSettings().getBoolean("reject_message_when_talking");
         private static bool importantMessagesBlockOtherMessages = UserSettings.GetUserSettings().getBoolean("immediate_messages_block_other_messages");
+        private static bool autoVerbosity = UserSettings.GetUserSettings().getBoolean("priortise_messages_depending_on_situation");
         private static bool lastSoundWasSpotter = false;
         private static AudioPlayer audioPlayer = null;
 
@@ -69,11 +70,15 @@ namespace CrewChiefV4.Audio
         public static void UpdateAutoVerbosity(GameStateData currenGameState)
         {
             verbosity = Verbosity.FULL;
+            if (!autoVerbosity)
+            {
+                return;
+            }
             if (currenGameState.SessionData.SessionType == SessionType.Race && currenGameState.PositionAndMotionData.CarSpeed > 5)
             {
                 // only interested if we're moving and it's a race session
-                 if ((currenGameState.SessionData.TimeDeltaFront < 2 && currenGameState.SessionData.TimeDeltaBehind < 2) ||
-                    (currenGameState.SessionData.TimeDeltaFront < 1 || currenGameState.SessionData.TimeDeltaBehind < 1))
+                 if ((currenGameState.SessionData.TimeDeltaFront < 3 && currenGameState.SessionData.TimeDeltaBehind < 3) ||
+                    (currenGameState.SessionData.TimeDeltaFront < 2 || currenGameState.SessionData.TimeDeltaBehind < 2))
                 {
                     verbosity = Verbosity.LOW;
                 }

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -90,7 +90,7 @@ namespace CrewChiefV4.Audio
             if (currentGameState.SessionData.SessionType == SessionType.Race && currentGameState.PositionAndMotionData.CarSpeed > 5)
             {
                 // only interested if we're moving and it's a race session
-                 if ((currentGameState.SessionData.TimeDeltaFront < 3 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
+                if ((currentGameState.SessionData.TimeDeltaFront < 3 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
                     currentGameState.SessionData.TimeDeltaFront < 2 || currentGameState.SessionData.TimeDeltaBehind < 2)
                 {
                     verbosity = Verbosity.LOW;
@@ -312,6 +312,10 @@ namespace CrewChiefV4.Audio
                 {
                     queuedMessageCounters.Add(queuedMessage.messageName, new MessageQueueCounter(now));
                 }
+            }
+            else
+            {
+                PlaybackModerator.Trace(string.Format("Message {} hasn't been queued because its priority is {} and our verbosity is currently {}", queuedMessage.messageName, priority, verbosity));
             }
             return canPlay;
         }

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -94,8 +94,10 @@ namespace CrewChiefV4.Audio
             {
                 if (currentGameState.SessionData.SessionType == SessionType.Race)
                 {
-                    if ((currentGameState.SessionData.TimeDeltaFront < 3 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
-                        currentGameState.SessionData.TimeDeltaFront < 2 || currentGameState.SessionData.TimeDeltaBehind < 2)
+                    if ((currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 3 && 
+                         currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 3) ||
+                        (currentGameState.SessionData.TimeDeltaFront > 0 && currentGameState.SessionData.TimeDeltaFront < 2) ||
+                        (currentGameState.SessionData.TimeDeltaBehind > 0 && currentGameState.SessionData.TimeDeltaBehind < 2))
                     {
                         verbosity = Verbosity.LOW;
                     }

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -322,9 +322,14 @@ namespace CrewChiefV4.Audio
                 priority = queuedMessage.metadata.priority;
                 type = queuedMessage.metadata.type;
             }
+
+           
             Boolean canPlay = priority >= PlaybackModerator.minPriorityForEachVerbosity[verbosity];            
             if (canPlay)
             {
+                // not using this Dictionary of played messages so no point in adding data to it. Will leave this code
+                // here for now in case i come up with a use-case
+                /*
                 MessageQueueCounter counter;
                 if (PlaybackModerator.queuedMessageCounters.TryGetValue(queuedMessage.messageName, out counter))
                 {
@@ -335,6 +340,7 @@ namespace CrewChiefV4.Audio
                 {
                     PlaybackModerator.queuedMessageCounters.Add(queuedMessage.messageName, new MessageQueueCounter(now));
                 }
+                */
             }
             else
             {

--- a/CrewChiefV4/Audio/PlaybackModerator.cs
+++ b/CrewChiefV4/Audio/PlaybackModerator.cs
@@ -70,7 +70,7 @@ namespace CrewChiefV4.Audio
             {Verbosity.SILENT, 20}
         };
 
-        public static void clearVerbosityData()
+        public static void ClearVerbosityData()
         {
             queuedMessageCounters.Clear();
             verbosity = Verbosity.FULL;
@@ -81,15 +81,15 @@ namespace CrewChiefV4.Audio
         {
             if (!autoVerbosity || currentGameState == null)
             {
-                verbosity = Verbosity.FULL;
+                PlaybackModerator.verbosity = Verbosity.FULL;
                 return;
             }
             if (currentGameState.Now < nextVerbosityUpdate)
             {
                 return;
             }
-            nextVerbosityUpdate = currentGameState.Now.AddSeconds(1);
-            verbosity = Verbosity.FULL;
+            PlaybackModerator.nextVerbosityUpdate = currentGameState.Now.AddSeconds(1);
+            PlaybackModerator.verbosity = Verbosity.FULL;
             if (currentGameState.PositionAndMotionData.CarSpeed > 5)
             {
                 if (currentGameState.SessionData.SessionType == SessionType.Race)
@@ -106,22 +106,22 @@ namespace CrewChiefV4.Audio
 
                     if (inCloseTraffic || hasCarVeryClose)
                     {
-                        verbosity = Verbosity.LOW;
+                        PlaybackModerator.verbosity = Verbosity.LOW;
                     }
                     else if (inTraffic || hasCarClose)
                     {
-                        verbosity = Verbosity.MED;
+                        PlaybackModerator.verbosity = Verbosity.MED;
                     }
                     else if (currentGameState.SessionData.CompletedLaps == 0 ||
                         (!currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.CompletedLaps + 1 >= currentGameState.SessionData.SessionNumberOfLaps) ||
                         (currentGameState.SessionData.SessionHasFixedTime && currentGameState.SessionData.SessionRunningTime + 120 >= currentGameState.SessionData.SessionTotalRunTime))
                     {
-                        verbosity = Verbosity.MED;
+                        PlaybackModerator.verbosity = Verbosity.MED;
                     }
                 }
                 else if (currentGameState.SessionData.SessionType == SessionType.Qualify && !currentGameState.PitData.OnOutLap && currentGameState.SessionData.CurrentLapIsValid)
                 {
-                    verbosity = Verbosity.MED;
+                    PlaybackModerator.verbosity = Verbosity.MED;
                 }
             }
         }
@@ -313,6 +313,7 @@ namespace CrewChiefV4.Audio
             SoundType type;
             if (queuedMessage.metadata == null)
             {
+                Console.WriteLine("Message " + queuedMessage.messageName + " has no metadata, setting priority and type to default");
                 priority = SoundMetadata.DEFAULT_PRIORITY;
                 type = SoundType.REGULAR_MESSAGE;
             }
@@ -321,18 +322,18 @@ namespace CrewChiefV4.Audio
                 priority = queuedMessage.metadata.priority;
                 type = queuedMessage.metadata.type;
             }
-            Boolean canPlay = priority >= minPriorityForEachVerbosity[verbosity];            
+            Boolean canPlay = priority >= PlaybackModerator.minPriorityForEachVerbosity[verbosity];            
             if (canPlay)
             {
                 MessageQueueCounter counter;
-                if (queuedMessageCounters.TryGetValue(queuedMessage.messageName, out counter))
+                if (PlaybackModerator.queuedMessageCounters.TryGetValue(queuedMessage.messageName, out counter))
                 {
                     counter.timeQueued = now;
                     counter.numberOfTimesQueued = counter.numberOfTimesQueued + 1;
                 }
                 else
                 {
-                    queuedMessageCounters.Add(queuedMessage.messageName, new MessageQueueCounter(now));
+                    PlaybackModerator.queuedMessageCounters.Add(queuedMessage.messageName, new MessageQueueCounter(now));
                 }
             }
             else

--- a/CrewChiefV4/Audio/SoundMetadata.cs
+++ b/CrewChiefV4/Audio/SoundMetadata.cs
@@ -20,11 +20,12 @@ namespace CrewChiefV4.Audio
 
     public class SoundMetadata
     {
+        public static int DEFAULT_PRIORITY = 5;
         public int messageId = 0;  // 0 => unset
         public SoundType type;
 
         // this affects the queue insertion order. Higher priority items are inserted at the head of the queue
-        public int priority = 5;  // 0 = lowest, 5 = default, 10 = spotter
+        public int priority = DEFAULT_PRIORITY;  // 0 = lowest, 5 = default, 10 = spotter
 
         // this has no messageId or priority because they're only ever single sounds
         public static SoundMetadata beep = new SoundMetadata(SoundType.OTHER);

--- a/CrewChiefV4/Audio/SoundMetadata.cs
+++ b/CrewChiefV4/Audio/SoundMetadata.cs
@@ -20,7 +20,7 @@ namespace CrewChiefV4.Audio
 
     public class SoundMetadata
     {
-        public static int DEFAULT_PRIORITY = 5;
+        public const int DEFAULT_PRIORITY = 5;
         public int messageId = 0;  // 0 => unset
         public SoundType type;
 

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -958,6 +958,9 @@ namespace CrewChiefV4
                                     }
                                     stateCleared = false;
                                 }
+                                // update the auto-verbosity
+                                PlaybackModerator.UpdateAutoVerbosity(currentGameState);
+
                                 // Allow events to be processed after session finish.  Event should use applicableSessionPhases/applicableSessionTypes to opt in/out.
                                 foreach (KeyValuePair<String, AbstractEvent> entry in eventsList)
                                 {

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -886,7 +886,7 @@ namespace CrewChiefV4
                             if (currentGameState.SessionData.IsNewSession)
                             {
                                 Console.WriteLine("New session");
-                                PlaybackModerator.clearVerbosityData();
+                                PlaybackModerator.ClearVerbosityData();
                                 PlaybackModerator.lastBlockedMessageId = -1;
                                 audioPlayer.disablePearlsOfWisdom = false;
                                 audioPlayer.resetSoundTypesInImmediateQueue();
@@ -1025,7 +1025,7 @@ namespace CrewChiefV4
             sessionFinished = false;
             faultingEvents.Clear();
             faultingEventsCount.Clear();
-            PlaybackModerator.clearVerbosityData();
+            PlaybackModerator.ClearVerbosityData();
             PlaybackModerator.lastBlockedMessageId = -1;
             audioPlayer.disablePearlsOfWisdom = false;
             audioPlayer.resetSoundTypesInImmediateQueue();

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -883,6 +883,7 @@ namespace CrewChiefV4
                             if (currentGameState.SessionData.IsNewSession)
                             {
                                 Console.WriteLine("New session");
+                                PlaybackModerator.clearPlayedMessageCounteras();
                                 PlaybackModerator.lastBlockedMessageId = -1;
                                 audioPlayer.disablePearlsOfWisdom = false;
                                 audioPlayer.resetSoundTypesInImmediateQueue();

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -883,8 +883,7 @@ namespace CrewChiefV4
                             if (currentGameState.SessionData.IsNewSession)
                             {
                                 Console.WriteLine("New session");
-                                PlaybackModerator.clearPlayedMessageCounters();
-                                PlaybackModerator.verbosity = Verbosity.FULL;
+                                PlaybackModerator.clearVerbosityData();
                                 PlaybackModerator.lastBlockedMessageId = -1;
                                 audioPlayer.disablePearlsOfWisdom = false;
                                 audioPlayer.resetSoundTypesInImmediateQueue();

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -883,7 +883,8 @@ namespace CrewChiefV4
                             if (currentGameState.SessionData.IsNewSession)
                             {
                                 Console.WriteLine("New session");
-                                PlaybackModerator.clearPlayedMessageCounteras();
+                                PlaybackModerator.clearPlayedMessageCounters();
+                                PlaybackModerator.verbosity = Verbosity.FULL;
                                 PlaybackModerator.lastBlockedMessageId = -1;
                                 audioPlayer.disablePearlsOfWisdom = false;
                                 audioPlayer.resetSoundTypesInImmediateQueue();

--- a/CrewChiefV4/Events/Battery.cs
+++ b/CrewChiefV4/Events/Battery.cs
@@ -377,7 +377,7 @@ namespace CrewChiefV4.Events
                         && !this.playedBatteryLowWarning)
                     {
                         this.playedBatteryLowWarning = true;
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, this));
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, this), 6);
                     }
                     else if (((this.averageUsagePerLap > 0.0f  // If avg usage per lap available, calculate threshold dynamically.
                             && this.windowedAverageChargeLeft < (this.averageUsagePerLap * Battery.BatteryCriticaLapsFactor))
@@ -385,7 +385,7 @@ namespace CrewChiefV4.Events
                         && !this.playedBatteryCriticalWarning)
                     {
                         this.playedBatteryCriticalWarning = true;
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderCriticalBattery), 0, this));
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderCriticalBattery), 0, this), 10);
                     }
                 }
 
@@ -437,44 +437,44 @@ namespace CrewChiefV4.Events
                             {
                                 if (currentGameState.PitData.IsElectricVehicleSwapAllowed)
                                 {
-                                    this.audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this));
-                                    this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderWeEstimate, estBattLapsLeft, Battery.folderLapsRemaining), 0, this));
+                                    this.audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 3);
+                                    this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderWeEstimate, estBattLapsLeft, Battery.folderLapsRemaining), 0, this), 3);
                                 }
                                 else
-                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, this));
+                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, this), 8);
                             }
                             else
-                                this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, this));
+                                this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, this), 3);
                         }
                         else if (raceLapsRemaining > 3 && estBattLapsLeft == 4 && !this.playedFourLapsRemaining)
                         {
                             this.playedFourLapsRemaining = true;
                             Console.WriteLine("4 laps of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFourLapsEstimate, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFourLapsEstimate, 0, this), 5);
                         }
                         else if (raceLapsRemaining > 2 && estBattLapsLeft == 3 && !this.playedThreeLapsRemaining)
                         {
                             this.playedThreeLapsRemaining = true;
                             Console.WriteLine("3 laps of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderThreeLapsEstimate, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderThreeLapsEstimate, 0, this), 7);
                         }
                         else if (raceLapsRemaining > 1 && estBattLapsLeft == 2 && !this.playedTwoLapsRemaining)
                         {
                             this.playedTwoLapsRemaining = true;
                             Console.WriteLine("2 laps of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoLapsEstimate, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoLapsEstimate, 0, this), 10);
                         }
                         else if (raceLapsRemaining > 0 && estBattLapsLeft == 1)
                         {
                             Console.WriteLine("1 lap of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderOneLapEstimate, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderOneLapEstimate, 0, this), 10);
 
                             // If we've not played the pit-now message, play it with a bit of a delay - should probably wait for sector3 here
                             // but i'd have to move some stuff around and I'm an idle fucker
                             if (!this.playedPitForBatteryNow && raceLapsRemaining > 1)
                             {
                                 this.playedPitForBatteryNow = true;
-                                this.audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 10, this));
+                                this.audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 10, this), 10);
                             }
                         }
                     }
@@ -509,15 +509,15 @@ namespace CrewChiefV4.Events
                                     if (currentGameState.PitData.IsElectricVehicleSwapAllowed)
                                     {
                                         var minutesLeft = (int)Math.Floor(prevLapStats.AverageBatteryPercentageLeft / this.averageUsagePerMinute);
-                                        this.audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this));
+                                        this.audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 3);
                                         this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(
-                                            Battery.folderWeEstimate, minutesLeft, Battery.folderMinutesRemaining), 0, this));
+                                            Battery.folderWeEstimate, minutesLeft, Battery.folderMinutesRemaining), 0, this), 3);
                                     }
                                     else
-                                        this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, this));
+                                        this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, this), 8);
                                 }
                                 else
-                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, this));
+                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, this), 3);
                             }
                         }
 
@@ -539,11 +539,11 @@ namespace CrewChiefV4.Events
                             if (currentGameState.SessionData.SessionTimeRemaining > cutoffForVehicleSwapCall)
                             {
                                 this.audioPlayer.playMessage(new QueuedMessage("pit_for_vehicle_swap_now",
-                                    MessageContents(Battery.folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), 0, this));
+                                    MessageContents(Battery.folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), 0, this), 10);
                             }
                             else
                             {
-                                this.audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_battery", MessageContents(Battery.folderAboutToRunOut), 0, this));
+                                this.audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_battery", MessageContents(Battery.folderAboutToRunOut), 0, this), 10);
                             }
                         }
                         if (estBattMinsLeft <= 2.0f && estBattMinsLeft > 1.8f && !this.playedTwoMinutesRemaining)
@@ -553,7 +553,7 @@ namespace CrewChiefV4.Events
                             this.playedTwoMinutesRemaining = true;
                             this.playedFiveMinutesRemaining = true;
                             this.playedTenMinutesRemaining = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoMinutesBattery, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoMinutesBattery, 0, this), 10);
                         }
                         else if (estBattMinsLeft <= 5.0f && estBattMinsLeft > 4.8f && !this.playedFiveMinutesRemaining)
                         {
@@ -561,14 +561,14 @@ namespace CrewChiefV4.Events
 
                             this.playedFiveMinutesRemaining = true;
                             this.playedTenMinutesRemaining = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFiveMinutesBattery, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFiveMinutesBattery, 0, this), 8);
                         }
                         else if (estBattMinsLeft <= 10.0f && estBattMinsLeft > 9.8f && !this.playedTenMinutesRemaining)
                         {
                             Console.WriteLine("Less than 10 mins of battery charge left, " + battStatusMsg);
 
                             this.playedTenMinutesRemaining = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTenMinutesBattery, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTenMinutesBattery, 0, this), 5);
                         }
                         else if (!this.playedHalfBatteryChargeWarning && this.windowedAverageChargeLeft / this.initialBatteryChargePercentage <= 0.55f &&
                             this.windowedAverageChargeLeft / this.initialBatteryChargePercentage >= 0.45f)
@@ -577,7 +577,7 @@ namespace CrewChiefV4.Events
 
                             // warning message for battery left - these play as soon previous lap average charge drops below 1/2.
                             this.playedHalfBatteryChargeWarning = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfChargeWarning, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfChargeWarning, 0, this), 3);
                         }
                     }  // if Timed or fixed lap race
 
@@ -591,13 +591,13 @@ namespace CrewChiefV4.Events
                         if (bu == Battery.BatteryUseTrend.Increasing
                             && this.lastReportedTrend != Battery.BatteryUseTrend.Increasing)
                         {
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseIncreasing), Utilities.random.Next(0, 11), this));
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseIncreasing), Utilities.random.Next(0, 11), this), 3);
                             this.lastReportedTrend = Battery.BatteryUseTrend.Increasing;
                         }
                         else if (bu == Battery.BatteryUseTrend.Decreasing
                             && this.lastReportedTrend != Battery.BatteryUseTrend.Decreasing)
                         {
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseDecreasing), Utilities.random.Next(0, 11), this));
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseDecreasing), Utilities.random.Next(0, 11), this), 3);
                             this.lastReportedTrend = Battery.BatteryUseTrend.Decreasing;
                         }
                         else if (bu == Battery.BatteryUseTrend.Stable)
@@ -771,7 +771,7 @@ namespace CrewChiefV4.Events
                         if (useImmediateQueue)
                             this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, null));
                         else
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, this), 1);
                     }
                     else
                     {
@@ -783,7 +783,7 @@ namespace CrewChiefV4.Events
                         if (useImmediateQueue)
                             this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, null));
                         else
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, this));
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, this), 1);
 
                     }
                 }
@@ -823,7 +823,7 @@ namespace CrewChiefV4.Events
                 if (useImmediateQueue)
                     this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", messageFragments, 0, null));
                 else
-                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", messageFragments, 0, null));
+                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", messageFragments, 0, null), 5);
             }
             else if ((this.averageUsagePerLap > 0.0f  // If avg usage per lap available, calculate threshold dynamically.
                     && this.windowedAverageChargeLeft > (this.averageUsagePerLap * Battery.BatteryCriticaLapsFactor))
@@ -833,7 +833,7 @@ namespace CrewChiefV4.Events
                 if (useImmediateQueue)
                     this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, null));
                 else
-                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, this));
+                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, this), 5);
             }
             else if (this.windowedAverageChargeLeft > 0)
             {
@@ -845,7 +845,7 @@ namespace CrewChiefV4.Events
                 if (useImmediateQueue)
                     this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", messageFragments, 0, null));
                 else
-                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", messageFragments, 0, null));
+                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", messageFragments, 0, null), 5);
             }
 
             if (batteryRunningLow || !this.batteryUseActive)
@@ -869,7 +869,7 @@ namespace CrewChiefV4.Events
                     if (useImmediateQueue)
                         this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null));
                     else
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null));
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null), 5);
                 else
                 {
                     var messageFragments = new List<MessageFragment>();
@@ -879,7 +879,7 @@ namespace CrewChiefV4.Events
                     if (useImmediateQueue)
                         this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", messageFragments, 0, null));
                     else
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", messageFragments, 0, null));
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", messageFragments, 0, null), 5);
                 }
             }
             else if (this.averageUsagePerMinute > 0.0f) // Timed race.
@@ -900,7 +900,7 @@ namespace CrewChiefV4.Events
                     if (useImmediateQueue)
                         this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null));
                     else
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null));
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null), 10);
                 else
                 {
                     var messageFragments = new List<MessageFragment>();

--- a/CrewChiefV4/Events/ConditionsMonitor.cs
+++ b/CrewChiefV4/Events/ConditionsMonitor.cs
@@ -151,7 +151,7 @@ namespace CrewChiefV4.Events
                             // do the reporting
                             audioPlayer.playMessage(new QueuedMessage("airAndTrackTemp", MessageContents
                                 (folderAirAndTrackTempIncreasing, folderAirTempIsNow, convertTemp(currentConditions.AmbientTemperature),
-                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), 0, this));
+                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
                             reportedCombinedTemps = true;
                         }
                         else if (trackTempToUse < trackTempAtLastReport - minTrackTempDeltaToReport && currentConditions.AmbientTemperature < airTempAtLastReport - minAirTempDeltaToReport)
@@ -163,7 +163,7 @@ namespace CrewChiefV4.Events
                             // do the reporting
                             audioPlayer.playMessage(new QueuedMessage("airAndTrackTemp", MessageContents
                                 (folderAirAndTrackTempDecreasing, folderAirTempIsNow, convertTemp(currentConditions.AmbientTemperature),
-                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), 0, this));
+                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
                             reportedCombinedTemps = true;
                         }
                     }
@@ -175,7 +175,7 @@ namespace CrewChiefV4.Events
                             lastAirTempReport = currentGameState.Now;
                             // do the reporting
                             audioPlayer.playMessage(new QueuedMessage("airTemp", MessageContents
-                                (folderAirTempIncreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this));
+                                (folderAirTempIncreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this), 0);
                         }
                         else if (currentConditions.AmbientTemperature < airTempAtLastReport - minAirTempDeltaToReport)
                         {
@@ -183,7 +183,7 @@ namespace CrewChiefV4.Events
                             lastAirTempReport = currentGameState.Now;
                             // do the reporting
                             audioPlayer.playMessage(new QueuedMessage("airTemp", MessageContents
-                                (folderAirTempDecreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this));
+                                (folderAirTempDecreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this), 0);
                         }
                     }
                     if (!reportedCombinedTemps && canReportTrackChange)
@@ -194,7 +194,7 @@ namespace CrewChiefV4.Events
                             lastTrackTempReport = currentGameState.Now;
                             // do the reporting
                             audioPlayer.playMessage(new QueuedMessage("trackTemp", MessageContents
-                                (folderTrackTempIncreasing, convertTemp(trackTempToUse), getTempUnit()), 0, this));
+                                (folderTrackTempIncreasing, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
                         }
                         else if (trackTempToUse < trackTempAtLastReport - minTrackTempDeltaToReport)
                         {
@@ -202,7 +202,7 @@ namespace CrewChiefV4.Events
                             lastTrackTempReport = currentGameState.Now;
                             // do the reporting
                             audioPlayer.playMessage(new QueuedMessage("trackTemp", MessageContents
-                                (folderTrackTempDecreasing, convertTemp(trackTempToUse), getTempUnit()), 0, this));
+                                (folderTrackTempDecreasing, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
                         }
                     }
                     //pcars2 test warning
@@ -242,7 +242,7 @@ namespace CrewChiefV4.Events
                                     }
                                     if (minutes > 1)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("expecting_rain", MessageContents(folderExpectRain, minutes, NumberReader.folderMinutes), 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage("expecting_rain", MessageContents(folderExpectRain, minutes, NumberReader.folderMinutes), 0, this), 5);
                                     }
                                 }
                             }
@@ -263,13 +263,13 @@ namespace CrewChiefV4.Events
                             {
                                 rainAtLastReport = currentGameState.RainDensity;
                                 lastRainReport = currentGameState.Now;
-                                audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 0, this), 2);
                             }
                             else if (currentConditions.RainDensity == 1 && rainAtLastReport == 0)
                             {
                                 rainAtLastReport = currentGameState.RainDensity;
                                 lastRainReport = currentGameState.Now;
-                                audioPlayer.playMessage(new QueuedMessage(folderSeeingSomeRain, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderSeeingSomeRain, 0, this), 5);
                             }
                         }
                         else if (CrewChief.gameDefinition.gameEnum == GameEnum.RF2_64BIT)
@@ -282,22 +282,22 @@ namespace CrewChiefV4.Events
                                 switch (currentRainLevel)
                                 {
                                     case RainLevel.DRIZZLE:
-                                        audioPlayer.playMessage(new QueuedMessage(folderDrizzleIncreasing, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderDrizzleIncreasing, 0, this), 3);
                                         break;
                                     case RainLevel.LIGHT:
-                                        audioPlayer.playMessage(new QueuedMessage(increasing ? folderRainLightIncreasing : folderRainLightDecreasing, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(increasing ? folderRainLightIncreasing : folderRainLightDecreasing, 0, this), 3);
                                         break;
                                     case RainLevel.MID:
-                                        audioPlayer.playMessage(new QueuedMessage(increasing ? folderRainMidIncreasing : folderRainMidDecreasing, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(increasing ? folderRainMidIncreasing : folderRainMidDecreasing, 0, this), 3);
                                         break;
                                     case RainLevel.HEAVY:
-                                        audioPlayer.playMessage(new QueuedMessage(increasing ? folderRainHeavyIncreasing : folderRainHeavyDecreasing, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(increasing ? folderRainHeavyIncreasing : folderRainHeavyDecreasing, 0, this), 3);
                                         break;
                                     case RainLevel.STORM:
-                                        audioPlayer.playMessage(new QueuedMessage(folderRainMax, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderRainMax, 0, this), 3);
                                         break;
                                     case RainLevel.NONE:
-                                        audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 0, this), 3);
                                         break;
                                 }
                                 lastRainReport = currentGameState.Now;

--- a/CrewChiefV4/Events/DamageReporting.cs
+++ b/CrewChiefV4/Events/DamageReporting.cs
@@ -347,16 +347,16 @@ namespace CrewChiefV4.Events
                     switch (puncture)
                     {
                         case CornerData.Corners.FRONT_LEFT:
-                            audioPlayer.playMessage(new QueuedMessage(folderLeftFrontPuncture, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderLeftFrontPuncture, 0, this), 10);
                             break;
                         case CornerData.Corners.FRONT_RIGHT:
-                            audioPlayer.playMessage(new QueuedMessage(folderRightFrontPuncture, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderRightFrontPuncture, 0, this), 10);
                             break;
                         case CornerData.Corners.REAR_LEFT:
-                            audioPlayer.playMessage(new QueuedMessage(folderLeftRearPuncture, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderLeftRearPuncture, 0, this), 10);
                             break;
                         case CornerData.Corners.REAR_RIGHT:
-                            audioPlayer.playMessage(new QueuedMessage(folderRightRearPuncture, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderRightRearPuncture, 0, this), 10);
                             break;
                     }
                 }
@@ -787,7 +787,7 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderBustedEngine, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderBustedEngine, 0, this), 10);
                         if (allowRants)
                         {
                             audioPlayer.playRant("damage_rant", null);
@@ -796,11 +796,11 @@ namespace CrewChiefV4.Events
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereEngineDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereEngineDamage, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorEngineDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorEngineDamage, 0, this), 10);
                 }
             }
             else if (damageToReportNext.Item1 == Component.TRANNY)
@@ -809,7 +809,7 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderBustedTransmission, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderBustedTransmission, 0, this), 10);
                         if (allowRants)
                         {
                             audioPlayer.playRant("damage_rant", null);
@@ -818,11 +818,11 @@ namespace CrewChiefV4.Events
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereTransmissionDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereTransmissionDamage, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorTransmissionDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorTransmissionDamage, 0, this), 10);
                 }
             }
             else if (damageToReportNext.Item1 == Component.SUSPENSION)
@@ -831,7 +831,7 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderBustedSuspension, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderBustedSuspension, 0, this), 10);
                         if (allowRants)
                         {
                             audioPlayer.playRant("damage_rant", null);
@@ -842,28 +842,28 @@ namespace CrewChiefV4.Events
                 {
                     if (isMissingWheel)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderMissingWheel, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderMissingWheel, 0, this), 10);
                     }
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereSuspensionDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereSuspensionDamage, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR && !isMissingWheel)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorSuspensionDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorSuspensionDamage, 0, this), 10);
                 }
             }
             else if (damageToReportNext.Item1 == Component.BRAKES)
             {
                 if (damageToReportNext.Item2 == DamageLevel.DESTROYED)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderBustedBrakes, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderBustedBrakes, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereBrakeDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereBrakeDamage, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorBrakeDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorBrakeDamage, 0, this), 10);
                 }
             }
             else if (damageToReportNext.Item1 == Component.AERO)
@@ -872,20 +872,20 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, this), 10);
                     }
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorAeroDamage, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorAeroDamage, 0, this), 10);
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.TRIVIAL)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderJustAScratch, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderJustAScratch, 0, this), 3);
                 }
             }
         }
@@ -898,12 +898,12 @@ namespace CrewChiefV4.Events
                 if (speed < 2 && isUpsideDown(orientationSamples.Last.Value))
                 {
                     // we're almost stopped and we're upside down
-                    audioPlayer.playMessage(new QueuedMessage(folderStoppedUpsideDown, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderStoppedUpsideDown, 0, this), 3);
                 }
                 else
                 {
                     // we may be rolling, or may have reset and are now racing again:
-                    audioPlayer.playMessage(new QueuedMessage(folderRolled, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderRolled, 0, this), 3);
                 }
                 // don't check again for a while:
                 isRolling = false;

--- a/CrewChiefV4/Events/EngineMonitor.cs
+++ b/CrewChiefV4/Events/EngineMonitor.cs
@@ -91,13 +91,13 @@ namespace CrewChiefV4.Events
                     // don't check oil or fuel pressure if we're stalled
                     if (currentGameState.EngineData.EngineOilPressureWarning && currentGameState.Now > nextOilPressureCheck)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLowOilPressure, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLowOilPressure, 0, this), 10);
                         // don't re-check oil pressure for a couple of minutes
                         nextOilPressureCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     }
                     if (currentGameState.EngineData.EngineFuelPressureWarning && currentGameState.Now > nextFuelPressureCheck)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLowFuelPressure, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLowFuelPressure, 0, this), 10);
                         // don't re-check fuel pressure for a couple of minutes
                         nextFuelPressureCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     }
@@ -119,12 +119,12 @@ namespace CrewChiefV4.Events
                         if (currentEngineStatus.HasFlag(EngineStatus.ALL_CLEAR))
                         {
                             lastStatusMessage = currentEngineStatus;
-                            audioPlayer.playMessage(new QueuedMessage(folderAllClear, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderAllClear, 0, this), 5);
                         }
                         else if (currentEngineStatus.HasFlag(EngineStatus.HOT_OIL) && currentEngineStatus.HasFlag(EngineStatus.HOT_WATER))
                         {
                             lastStatusMessage = currentEngineStatus;
-                            audioPlayer.playMessage(new QueuedMessage(folderHotOilAndWater, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderHotOilAndWater, 0, this), 10);
                         }
                         if (currentEngineStatus.HasFlag(EngineStatus.HOT_OIL))
                         {
@@ -132,7 +132,7 @@ namespace CrewChiefV4.Events
                             if (!lastStatusMessage.HasFlag(EngineStatus.HOT_OIL) && !lastStatusMessage.HasFlag(EngineStatus.HOT_WATER))
                             {
                                 lastStatusMessage = currentEngineStatus;
-                                audioPlayer.playMessage(new QueuedMessage(folderHotOil, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderHotOil, 0, this), 10);
                             }
                         }
                         if (currentEngineStatus.HasFlag(EngineStatus.HOT_WATER))
@@ -141,7 +141,7 @@ namespace CrewChiefV4.Events
                             if (!lastStatusMessage.HasFlag(EngineStatus.HOT_OIL) && !lastStatusMessage.HasFlag(EngineStatus.HOT_WATER))
                             {
                                 lastStatusMessage = currentEngineStatus;
-                                audioPlayer.playMessage(new QueuedMessage(folderHotWater, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderHotWater, 0, this), 10);
                             }
                         }
                     }

--- a/CrewChiefV4/Events/FlagsMonitor.cs
+++ b/CrewChiefV4/Events/FlagsMonitor.cs
@@ -349,7 +349,7 @@ namespace CrewChiefV4.Events
                 if (currentGameState.Now > disableBlackFlagUntil)
                 {
                     disableBlackFlagUntil = currentGameState.Now.Add(timeBetweenBlackFlagMessages);
-                    audioPlayer.playMessage(new QueuedMessage(folderBlackFlag, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderBlackFlag, 0, this), 10);
                 }
             }
             else if (!currentGameState.PitData.InPitlane && currentGameState.SessionData.Flag == FlagEnum.BLUE)
@@ -367,7 +367,7 @@ namespace CrewChiefV4.Events
                 if (currentGameState.Now > disableWhiteFlagUntil)
                 {
                     disableWhiteFlagUntil = currentGameState.Now.Add(timeBetweenWhiteFlagMessages);
-                    audioPlayer.playMessage(new QueuedMessage(folderWhiteFlagEU, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderWhiteFlagEU, 0, this), 10);
                 }
             }
             if (currentGameState.FlagData.numCarsPassedIllegally >= 0
@@ -415,23 +415,23 @@ namespace CrewChiefV4.Events
                         Console.WriteLine("Stock Car Rule triggered: " + currentGameState.StockCarRulesData.stockCarRuleApplicable);
                         if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.LUCKY_DOG_PASS_ON_LEFT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderWeAreLuckyDog, Utilities.random.Next(3, 7), this));
+                            audioPlayer.playMessage(new QueuedMessage(folderWeAreLuckyDog, Utilities.random.Next(3, 7), this), 10);
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.LUCKY_DOG_ALLOW_TO_PASS_ON_LEFT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderAllowLuckyDogPass, Utilities.random.Next(3, 7), this));
+                            audioPlayer.playMessage(new QueuedMessage(folderAllowLuckyDogPass, Utilities.random.Next(3, 7), this), 10);
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.LEADER_CHOOSE_LANE)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderLeaderChooseLane, Utilities.random.Next(3, 7), this));
+                            audioPlayer.playMessage(new QueuedMessage(folderLeaderChooseLane, Utilities.random.Next(3, 7), this), 10);
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.WAVE_AROUND_PASS_ON_RIGHT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderWeHaveBeenWavedAround, Utilities.random.Next(3, 7), this));
+                            audioPlayer.playMessage(new QueuedMessage(folderWeHaveBeenWavedAround, Utilities.random.Next(3, 7), this), 10);
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.MOVE_TO_EOLL)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderEOLLPenalty, Utilities.random.Next(3, 7), this));
+                            audioPlayer.playMessage(new QueuedMessage(folderEOLLPenalty, Utilities.random.Next(3, 7), this), 10);
                         }
                     }
                 }
@@ -447,7 +447,7 @@ namespace CrewChiefV4.Events
                         if (currentGreenFlagLuckyDogStatus == GreenFlagLuckyDogStatus.WE_ARE_IN_LUCKY_DOG)
                         {
                             Console.WriteLine("Stock Car Rule triggered: " + currentGreenFlagLuckyDogStatus);
-                            audioPlayer.playMessage(new QueuedMessage(folderWeAreInLuckyDogPosition, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderWeAreInLuckyDogPosition, 0, this), 10);
                         }
                         else if (currentGreenFlagLuckyDogStatus == GreenFlagLuckyDogStatus.PASS_FOR_LUCKY_DOG)
                         {
@@ -455,12 +455,12 @@ namespace CrewChiefV4.Events
                             Console.WriteLine("Stock Car Rule triggered: " + currentGreenFlagLuckyDogStatus + " driver to pass: " + (carAhead != null ? carAhead.DriverRawName : "not found"));
                             if (carAhead != null && AudioPlayer.canReadName(carAhead.DriverRawName))
                             {
-                                audioPlayer.playMessage(new QueuedMessage("push_to_pass_lucky_dog", 
-                                    MessageContents(folderPassDriverForLuckyDogPositionIntro, carAhead, folderPassDriverForLuckyDogPositionOutro), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("push_to_pass_lucky_dog",
+                                    MessageContents(folderPassDriverForLuckyDogPositionIntro, carAhead, folderPassDriverForLuckyDogPositionOutro), 0, this), 10);
                             }
                             else
                             {
-                                audioPlayer.playMessage(new QueuedMessage(folderPassCarAheadForLuckyPositionDog, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderPassCarAheadForLuckyPositionDog, 0, this), 10);
                             }
                         }
                         greenFlagLuckyDogMessageCountInSession++;
@@ -632,37 +632,37 @@ namespace CrewChiefV4.Events
                         case FullCourseYellowPhase.PITS_CLOSED:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsClosedUS : folderFCYellowPitsClosedEU, Utilities.random.Next(1, 4), this));
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsClosedUS : folderFCYellowPitsClosedEU, Utilities.random.Next(1, 4), this), 10);
                             }
                             break;
                         case FullCourseYellowPhase.PITS_OPEN_LEAD_LAP_VEHICLES:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenLeadLapCarsUS : folderFCYellowPitsOpenLeadLapCarsEU, Utilities.random.Next(1, 4), this));
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenLeadLapCarsUS : folderFCYellowPitsOpenLeadLapCarsEU, Utilities.random.Next(1, 4), this), 10);
                             }
                             break;
                         case FullCourseYellowPhase.PITS_OPEN:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenUS : folderFCYellowPitsOpenEU, Utilities.random.Next(1, 4), this));
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenUS : folderFCYellowPitsOpenEU, Utilities.random.Next(1, 4), this), 10);
                             }
                             break;
                         case FullCourseYellowPhase.IN_PROGRESS:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowInProgressUS : folderFCYellowInProgressEU, Utilities.random.Next(1, 4), this));
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowInProgressUS : folderFCYellowInProgressEU, Utilities.random.Next(1, 4), this), 10);
                             }
                             break;
                         case FullCourseYellowPhase.LAST_LAP_NEXT:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapNextUS : folderFCYellowLastLapNextEU, Utilities.random.Next(1, 4), this));
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapNextUS : folderFCYellowLastLapNextEU, Utilities.random.Next(1, 4), this), 10);
                             }
                             break;
                         case FullCourseYellowPhase.LAST_LAP_CURRENT:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapCurrentUS : folderFCYellowLastLapCurrentEU, Utilities.random.Next(1, 4), this));
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapCurrentUS : folderFCYellowLastLapCurrentEU, Utilities.random.Next(1, 4), this), 10);
                             }
                             break;
                         case FullCourseYellowPhase.RACING:

--- a/CrewChiefV4/Events/FrozenOrderMonitor.cs
+++ b/CrewChiefV4/Events/FrozenOrderMonitor.cs
@@ -173,9 +173,9 @@ namespace CrewChiefV4.Events
                 Console.WriteLine("Frozen Order: New Phase detected: " + cfod.Phase);
 
                 if (cfod.Phase == FrozenOrderPhase.Rolling)
-                    audioPlayer.playMessage(new QueuedMessage(folderRollingStartReminder, Utilities.random.Next(0, 3), this));
+                    audioPlayer.playMessage(new QueuedMessage(folderRollingStartReminder, Utilities.random.Next(0, 3), this), 10);
                 else if (cfod.Phase == FrozenOrderPhase.FormationStanding)
-                    audioPlayer.playMessage(new QueuedMessage(folderStandingStartReminder, Utilities.random.Next(0, 3), this));
+                    audioPlayer.playMessage(new QueuedMessage(folderStandingStartReminder, Utilities.random.Next(0, 3), this), 10);
 
                 // Clear previous state.
                 this.clearState();
@@ -243,7 +243,7 @@ namespace CrewChiefV4.Events
                             if (cfod.AssignedColumn == FrozenOrderColumn.None
                                 || Utilities.random.Next(1, 11) > 8)  // Randomly, announce message without coulmn info.
                                 audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car",
-                                    MessageContents(folderFollow, usableDriverNameToFollow), Utilities.random.Next(3, 6), this, validationData));
+                                    MessageContents(folderFollow, usableDriverNameToFollow), Utilities.random.Next(3, 6), this, validationData), 10);
                             else
                             {
                                 string columnName;
@@ -251,7 +251,7 @@ namespace CrewChiefV4.Events
                                     columnName = cfod.AssignedColumn == FrozenOrderColumn.Left ? folderInTheInsideColumn : folderInTheOutsideColumn;
                                 else
                                     columnName = cfod.AssignedColumn == FrozenOrderColumn.Left ? folderInTheLeftColumn : folderInTheRightColumn;
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_col" : "frozen_order/follow_safecy_car_in_col", MessageContents(folderFollow, usableDriverNameToFollow, columnName), Utilities.random.Next(3, 6), this, validationData));
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_col" : "frozen_order/follow_safecy_car_in_col", MessageContents(folderFollow, usableDriverNameToFollow, columnName), Utilities.random.Next(3, 6), this, validationData), 10);
                             }
                         }
                     }
@@ -260,17 +260,17 @@ namespace CrewChiefV4.Events
                         // Follow messages are only meaningful if there's name to announce.
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
                             audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/allow_driver_to_pass" : "frozen_order/allow_safety_car_to_pass",
-                                MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), Utilities.random.Next(1, 4), this, validationData));
+                                MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), Utilities.random.Next(1, 4), this, validationData), 10);
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, Utilities.random.Next(1, 4), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, Utilities.random.Next(1, 4), this, validationData), 10);
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.CatchUp)
                     {
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
                             audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/catch_up_to_driver" : "frozen_order/catch_up_to_safety_car",
-                                MessageContents(folderCatchUpTo, usableDriverNameToFollow), Utilities.random.Next(1, 4), this, validationData));
+                                MessageContents(folderCatchUpTo, usableDriverNameToFollow), Utilities.random.Next(1, 4), this, validationData), 10);
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, Utilities.random.Next(1, 4), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, Utilities.random.Next(1, 4), this, validationData), 10);
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.StayInPole
                         && prevFrozenOrderAction != FrozenOrderAction.MoveToPole)  // No point in nagging user to stay in pole if we previously told them to move there.
@@ -278,7 +278,7 @@ namespace CrewChiefV4.Events
                         if (cfod.AssignedColumn == FrozenOrderColumn.None
                             || Utilities.random.Next(1, 11) > 8)  // Randomly, announce message without coulmn info.
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole",
-                                MessageContents(folderStayInPole), Utilities.random.Next(0, 3), this, validationData));
+                                MessageContents(folderStayInPole), Utilities.random.Next(0, 3), this, validationData), 10);
                         else
                         {
                             string folderToPlay = null;
@@ -287,17 +287,17 @@ namespace CrewChiefV4.Events
                             else
                                 folderToPlay = cfod.AssignedColumn == FrozenOrderColumn.Left ? folderStayInPoleInLeftColumn : folderStayInPoleInRightColumn;
 
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole_in_column", MessageContents(folderToPlay), Utilities.random.Next(0, 3), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole_in_column", MessageContents(folderToPlay), Utilities.random.Next(0, 3), this, validationData), 10);
                         }
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.MoveToPole)
                     {
                         if (cfod.AssignedColumn == FrozenOrderColumn.None)
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/move_to_pole",
-                                MessageContents(folderMoveToPole), Utilities.random.Next(2, 5), this, validationData));
+                                MessageContents(folderMoveToPole), Utilities.random.Next(2, 5), this, validationData), 10);
                         else
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/move_to_pole_row",
-                                MessageContents(folderMoveToPoleRow), Utilities.random.Next(2, 5), this, validationData));
+                                MessageContents(folderMoveToPoleRow), Utilities.random.Next(2, 5), this, validationData), 10);
                     }
                 }
             }
@@ -340,34 +340,34 @@ namespace CrewChiefV4.Events
                         if (canReadDriverToFollow)
                         {
                             if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Left)
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_left" : "frozen_order/follow_safety_car_in_left", MessageContents(folderFollow, usableDriverNameToFollow, 
-                                    useOvalLogic ? folderInTheInsideColumn : folderInTheLeftColumn), Utilities.random.Next(0, 3), this, validationData));
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_left" : "frozen_order/follow_safety_car_in_left", MessageContents(folderFollow, usableDriverNameToFollow,
+                                    useOvalLogic ? folderInTheInsideColumn : folderInTheLeftColumn), Utilities.random.Next(0, 3), this, validationData), 10);
                             else if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Right)
                                 audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_right" : "frozen_order/follow_safety_car_in_right",
-                                    MessageContents(folderFollow, usableDriverNameToFollow, useOvalLogic ? folderInTheOutsideColumn : folderInTheRightColumn), Utilities.random.Next(0, 3), this, validationData));
+                                    MessageContents(folderFollow, usableDriverNameToFollow, useOvalLogic ? folderInTheOutsideColumn : folderInTheRightColumn), Utilities.random.Next(0, 3), this, validationData), 10);
                             else
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car", MessageContents(folderFollow, usableDriverNameToFollow), Utilities.random.Next(0, 3), this, validationData));
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car", MessageContents(folderFollow, usableDriverNameToFollow), Utilities.random.Next(0, 3), this, validationData), 10);
                         }
                         else if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Left)
-                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInInsideColumn : folderLineUpInLeftColumn, Utilities.random.Next(0, 3), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInInsideColumn : folderLineUpInLeftColumn, Utilities.random.Next(0, 3), this, validationData), 10);
                         else if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Right)
-                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInOutsideColumn : folderLineUpInRightColumn, Utilities.random.Next(0, 3), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInOutsideColumn : folderLineUpInRightColumn, Utilities.random.Next(0, 3), this, validationData), 10);
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.AllowToPass)
                     {
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
-                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/allow_driver_to_pass" : "frozen_order/allow_safety_car_to_pass", 
-                                MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), Utilities.random.Next(1, 4), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/allow_driver_to_pass" : "frozen_order/allow_safety_car_to_pass",
+                                MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), Utilities.random.Next(1, 4), this, validationData), 10);
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, Utilities.random.Next(1, 4), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, Utilities.random.Next(1, 4), this, validationData), 10);
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.CatchUp)
                     {
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
-                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/catch_up_to_driver" : "frozen_order/catch_up_to_safety_car", 
-                                MessageContents(folderCatchUpTo, usableDriverNameToFollow), Utilities.random.Next(1, 4), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/catch_up_to_driver" : "frozen_order/catch_up_to_safety_car",
+                                MessageContents(folderCatchUpTo, usableDriverNameToFollow), Utilities.random.Next(1, 4), this, validationData), 10);
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, Utilities.random.Next(1, 4), this, validationData));
+                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, Utilities.random.Next(1, 4), this, validationData), 10);
                     }
                 }
             }
@@ -391,16 +391,16 @@ namespace CrewChiefV4.Events
                             audioPlayer.playMessage(new QueuedMessage(folderWereStartingFromPole, 0, this));
                         else
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pole_in_column",
-                                    MessageContents(folderWereStartingFromPole, columnName), Utilities.random.Next(0, 3), this));
+                                    MessageContents(folderWereStartingFromPole, columnName), Utilities.random.Next(0, 3), this), 10);
                     }
                     else
                     {
                         if (columnName == null)
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pos",
-                                    MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition), Utilities.random.Next(0, 3), this));
+                                    MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition), Utilities.random.Next(0, 3), this), 10);
                         else
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pos_row_in_column",
-                                    MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), Utilities.random.Next(0, 3), this));
+                                    MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), Utilities.random.Next(0, 3), this), 10);
                     }
                 }
 
@@ -414,19 +414,19 @@ namespace CrewChiefV4.Events
                     {
                         if (columnName == null)
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_starting_from_pole",
-                                    MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole), Utilities.random.Next(0, 3), this));
+                                    MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole), Utilities.random.Next(0, 3), this), 10);
                         else
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_starting_from_pole_in_column",
-                                    MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole, columnName), Utilities.random.Next(0, 3), this));
+                                    MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole, columnName), Utilities.random.Next(0, 3), this), 10);
                     }
                     else
                     {
                         if (columnName == null)
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_youre_starting_from_pos",
-                                    MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition), Utilities.random.Next(0, 3), this));
+                                    MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition), Utilities.random.Next(0, 3), this), 10);
                         else
                             audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_youre_starting_from_pos_row_in_column",
-                                    MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), Utilities.random.Next(0, 3), this));
+                                    MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), Utilities.random.Next(0, 3), this), 10);
                     }
                 }
             }
@@ -450,7 +450,7 @@ namespace CrewChiefV4.Events
                     messageFragments.Add(MessageFragment.Integer((int)Math.Round(kmPerHour), false));
                     messageFragments.Add(MessageFragment.Text(FrozenOrderMonitor.folderKilometresPerHour));
                 }
-                audioPlayer.playMessage(new QueuedMessage("frozen_order/pace_car_speed", messageFragments, Utilities.random.Next(10, 16), this));
+                audioPlayer.playMessage(new QueuedMessage("frozen_order/pace_car_speed", messageFragments, Utilities.random.Next(10, 16), this), 10);
             }
 
             // Announce SC left.

--- a/CrewChiefV4/Events/Fuel.cs
+++ b/CrewChiefV4/Events/Fuel.cs
@@ -415,13 +415,13 @@ namespace CrewChiefV4.Events
                             {
                                 // yes i know its not 2 liters but who really cares.
                                 played2LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderOneGallonRemaining), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderOneGallonRemaining), 0, this), 10);
                             }
                             else if (convertLitersToGallons(currentFuel) <= 0.5f && !played1LitreWarning)
                             {
                                 //^^
                                 played1LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderHalfAGallonRemaining), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderHalfAGallonRemaining), 0, this), 10);
                             }
                         }
                         else
@@ -429,12 +429,12 @@ namespace CrewChiefV4.Events
                             if (currentFuel <= 2 && !played2LitreWarning)
                             {
                                 played2LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(2, folderLitresRemaining), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(2, folderLitresRemaining), 0, this), 10);
                             }
                             else if (currentFuel <= 1 && !played1LitreWarning)
                             {
                                 played1LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderOneLitreRemaining), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderOneLitreRemaining), 0, this), 10);
                             }
                         }
 
@@ -454,17 +454,17 @@ namespace CrewChiefV4.Events
                                 {
                                     if (currentGameState.PitData.IsRefuellingAllowed)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this));
-                                        audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", MessageContents(folderWeEstimate, estimatedFuelLapsLeft, folderLapsRemaining), 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 7);
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", MessageContents(folderWeEstimate, estimatedFuelLapsLeft, folderLapsRemaining), 0, this), 7);
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, this), 7);
                                     }
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 3);
                                 }
                             }
                             else if (raceLapsRemaining > 3 && estimatedFuelLapsLeft == 4)
@@ -479,7 +479,7 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("4 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));  
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderFourLapsEstimate, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderFourLapsEstimate, 0, this), 3);
                             }
                             else if (raceLapsRemaining > 2 && estimatedFuelLapsLeft == 3)
                             {
@@ -493,6 +493,7 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("3 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));
                                 }
+                                audioPlayer.playMessage(new QueuedMessage(folderThreeLapsEstimate, 0, this), 5);
                             }
                             else if (raceLapsRemaining > 1 && estimatedFuelLapsLeft == 2)
                             {
@@ -506,6 +507,7 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("2 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));
                                 }
+                                audioPlayer.playMessage(new QueuedMessage(folderTwoLapsEstimate, 0, this), 7);
                             }
                             else if (raceLapsRemaining > 0 && estimatedFuelLapsLeft == 1)
                             {
@@ -519,13 +521,13 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("1 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));
                                 }                                
-                                audioPlayer.playMessage(new QueuedMessage(folderOneLapEstimate, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderOneLapEstimate, 0, this), 10);
                                 // if we've not played the pit-now message, play it with a bit of a delay - should probably wait for sector3 here
                                 // but i'd have to move some stuff around and I'm an idle fucker
                                 if (!playedPitForFuelNow && raceLapsRemaining > 1)
                                 {
                                     playedPitForFuelNow = true;
-                                    audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 10, this));
+                                    audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 10, this), 10);
                                 }
                             }
                         }
@@ -556,18 +558,18 @@ namespace CrewChiefV4.Events
                                         if (currentGameState.PitData.IsRefuellingAllowed)
                                         {
                                             int minutesLeft = (int)Math.Floor(currentGameState.FuelData.FuelLeft / averageUsagePerMinute);
-                                            audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 7);
                                             audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", MessageContents(
-                                                folderWeEstimate, minutesLeft, folderMinutesRemaining), 0, this));
+                                                folderWeEstimate, minutesLeft, folderMinutesRemaining), 0, this), 7);
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, this), 7);
                                         }
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 3);
                                     }
                                 }
                             }
@@ -590,12 +592,12 @@ namespace CrewChiefV4.Events
                                     if (currentGameState.SessionData.SessionTimeRemaining > cutoffForRefuelCall)
                                     {
                                         audioPlayer.playMessage(new QueuedMessage("pit_for_fuel_now",
-                                            MessageContents(folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), 0, this));
+                                            MessageContents(folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), 0, this), 10);
                                     }
                                     else
                                     {
                                         // going to run out, but don't call the player into the pits - it's up to him
-                                        audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_fuel", MessageContents(folderAboutToRunOut), 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_fuel", MessageContents(folderAboutToRunOut), 0, this), 10);
                                     }
                                 }
                             }
@@ -604,18 +606,18 @@ namespace CrewChiefV4.Events
                                 playedTwoMinutesRemaining = true;
                                 playedFiveMinutesRemaining = true;
                                 playedTenMinutesRemaining = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderTwoMinutesFuel, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderTwoMinutesFuel, 0, this), 10);
                             }
                             else if (estimatedFuelMinutesLeft <= 5 && estimatedFuelMinutesLeft > 4.8 && !playedFiveMinutesRemaining)
                             {
                                 playedFiveMinutesRemaining = true;
                                 playedTenMinutesRemaining = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderFiveMinutesFuel, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderFiveMinutesFuel, 0, this), 7);
                             }
                             else if (estimatedFuelMinutesLeft <= 10 && estimatedFuelMinutesLeft > 9.8 && !playedTenMinutesRemaining)
                             {
                                 playedTenMinutesRemaining = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderTenMinutesFuel, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderTenMinutesFuel, 0, this), 3);
 
                             }
                             else if (!playedHalfTankWarning && currentGameState.FuelData.FuelLeft / initialFuelLevel <= 0.50 && 
@@ -623,7 +625,7 @@ namespace CrewChiefV4.Events
                             {
                                 // warning message for fuel left - these play as soon as the fuel reaches 1/2 tank left
                                 playedHalfTankWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderHalfTankWarning, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderHalfTankWarning, 0, this), 0);
                             }
                         }
                     }
@@ -1178,7 +1180,7 @@ namespace CrewChiefV4.Events
             if (fuelCapacityInt > 0 && fuelCapacityInt < litresToEnd)
             {
                 // if we have a known fuel capacity and this is less than the calculated amount of fuel we need, warn about it.
-                audioPlayer.playMessage(new QueuedMessage(folderWillNeedToStopAgain, 4, this));
+                audioPlayer.playMessage(new QueuedMessage(folderWillNeedToStopAgain, 4, this), 10);
             }
             int maxPresses = fuelCapacityInt > 0 ? fuelCapacityInt : 200;
             return litresToEnd == -1 ? 0 : litresToEnd > maxPresses ? maxPresses : litresToEnd;

--- a/CrewChiefV4/Events/Fuel.cs
+++ b/CrewChiefV4/Events/Fuel.cs
@@ -464,7 +464,7 @@ namespace CrewChiefV4.Events
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 3);
+                                    audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 5);
                                 }
                             }
                             else if (raceLapsRemaining > 3 && estimatedFuelLapsLeft == 4)
@@ -569,7 +569,7 @@ namespace CrewChiefV4.Events
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 3);
+                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 5);
                                     }
                                 }
                             }

--- a/CrewChiefV4/Events/LapCounter.cs
+++ b/CrewChiefV4/Events/LapCounter.cs
@@ -300,7 +300,7 @@ namespace CrewChiefV4.Events
                     {
                         break;
                     }
-                    audioPlayer.playMessage(message);
+                    audioPlayer.playMessage(message, 10);
                 }
             }
             // TODO: in the countdown / pre-lights phase, we don't know how long the race is going to be so we can't use the 'get on with it' messages :(
@@ -378,7 +378,7 @@ namespace CrewChiefV4.Events
                          currentGameState.SessionData.SessionPhase == SessionPhase.Gridwalk))
                     {
                         playedPreLightsRollingStartWarning = true;
-                        audioPlayer.playMessage(new QueuedMessage(FrozenOrderMonitor.folderRollingStartReminder, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(FrozenOrderMonitor.folderRollingStartReminder, 0, this), 10);
                     }
 
                     // when the lights change to green, give some info:
@@ -424,7 +424,7 @@ namespace CrewChiefV4.Events
                             // empty the queue and play 'get ready'
                             int purgedCount = audioPlayer.purgeQueues();
                             Console.WriteLine("Purging pre-lights messages, removed = " + purgedCount + " messages");
-                            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this), 10);
                             playedGetReady = true;
                         }
                         else
@@ -500,7 +500,7 @@ namespace CrewChiefV4.Events
                         {
                             audioPlayer.purgeQueues();
                         }
-                        audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this), 10);
                         playedGetReady = true;
                     }
                 }
@@ -544,15 +544,15 @@ namespace CrewChiefV4.Events
                     Console.WriteLine("1 lap remaining, SessionHasFixedTime = " + currentGameState.SessionData.SessionHasFixedTime);
                     if (position == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 0, this), 10);
                     }
                     else if (position < 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLastLapTopThree, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLastLapTopThree, 0, this), 10);
                     }
                     else if (position > 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderLastLapUS : folderLastLapEU, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderLastLapUS : folderLastLapEU, 0, this), 10);
                     }
                     else
                     {
@@ -564,11 +564,11 @@ namespace CrewChiefV4.Events
                     Console.WriteLine("2 laps remaining, SessionHasFixedTime = " + currentGameState.SessionData.SessionHasFixedTime);
                     if (position == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftLeading, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftLeading, 0, this), 10);
                     }
                     else if (position < 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftTopThree, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftTopThree, 0, this), 10);
                     }
                     else if (position >= currentGameState.SessionData.SessionStartClassPosition + 5 &&
                         currentGameState.SessionData.LapTimePrevious > currentGameState.SessionData.PlayerLapTimeSessionBest)
@@ -577,12 +577,12 @@ namespace CrewChiefV4.Events
                         // might be invalid so perhaps they're really not being shit. At the moment.
                         if (CrewChief.gameDefinition.gameEnum != GameEnum.ASSETTO_32BIT && CrewChief.gameDefinition.gameEnum != GameEnum.ASSETTO_64BIT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 0, this), PearlsOfWisdom.PearlType.BAD, 0.5);
+                            audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 0, this), PearlsOfWisdom.PearlType.BAD, 0.5, 10);
                         }
                     }
                     else if (position >= 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, 0.5);
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, 0.5, 10);
                     }
                     else
                     {
@@ -614,7 +614,7 @@ namespace CrewChiefV4.Events
 
         private void playManualStartGetReady()
         {
-            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this));
+            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this), 10);
             playedManualStartGetReady = true;
         }
 
@@ -731,11 +731,11 @@ namespace CrewChiefV4.Events
             }
             if (opponentToLineUpBehind == null)
             {
-                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", messageContentsNoName, 0, this));
+                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", messageContentsNoName, 0, this), 10);
             }
             else
             {
-                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", messageContentsWithName, messageContentsNoName, 0, this));
+                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", messageContentsWithName, messageContentsNoName, 0, this), 10);
             }
             playedManualStartInitialMessage = true;
         }
@@ -762,18 +762,18 @@ namespace CrewChiefV4.Events
                         if (gridSide == GridSide.LEFT)
                         {
                             audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", MessageContents(folderManualStartInitialOutroWithDriverName1,
-                                    newOpponentToFollow, FrozenOrderMonitor.folderInTheLeftColumn), 0, this));
+                                    newOpponentToFollow, FrozenOrderMonitor.folderInTheLeftColumn), 0, this), 10);
                         }
                         else
                         {
                             audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", MessageContents(folderManualStartInitialOutroWithDriverName1,
-                                    newOpponentToFollow, FrozenOrderMonitor.folderInTheRightColumn), 0, this));
+                                    newOpponentToFollow, FrozenOrderMonitor.folderInTheRightColumn), 0, this), 10);
                         }
                     }
                     else
                     {
                         audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", MessageContents(folderManualStartInitialOutroWithDriverName1,
-                                    newOpponentToFollow), 0, this));
+                                    newOpponentToFollow), 0, this), 10);
                     }
                 }
             }
@@ -782,7 +782,7 @@ namespace CrewChiefV4.Events
                 if (!playedRejoinAtBackMessage)
                 {
                     playedRejoinAtBackMessage = true;
-                    audioPlayer.playMessage(new QueuedMessage("rejoin_at_back", MessageContents(folderManualStartRejoinAtBack), 0, this));
+                    audioPlayer.playMessage(new QueuedMessage("rejoin_at_back", MessageContents(folderManualStartRejoinAtBack), 0, this), 10);
                 }
                 setOpponentToFollowAndStartPosition(currentGameState, true, false);
             }
@@ -799,7 +799,7 @@ namespace CrewChiefV4.Events
 
                     audioPlayer.playMessage(new QueuedMessage("give_position_back",
                         MessageContents(folderGivePositionBack, folderManualStartInitialOutroWithDriverName1, getOpponent(currentGameState, manualStartOpponentToFollow)),
-                        MessageContents(folderGivePositionBack), 5, this, validationData));                    
+                        MessageContents(folderGivePositionBack), 5, this, validationData), 10);                    
                 }
             }
         }
@@ -834,7 +834,7 @@ namespace CrewChiefV4.Events
                     if (poleSitter.Speed - leaderSpeedAtAccelerationCheckStart > 5)
                     {
                         Console.WriteLine("Looks like the leader has 'gone'");
-                        audioPlayer.playMessage(new QueuedMessage(folderManualStartLeaderHasGone, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderManualStartLeaderHasGone, 0, this), 10);
                         leaderHasGone = true;
                     }
                 }
@@ -881,11 +881,11 @@ namespace CrewChiefV4.Events
                 }
                 if (opponentToLineUpBehind == null)
                 {
-                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", messageContentsNoName, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", messageContentsNoName, 0, this), 10);
                 }
                 else
                 {
-                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", messageContentsWithName, messageContentsNoName, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", messageContentsWithName, messageContentsNoName, 0, this), 10);
                 }
             }
         }

--- a/CrewChiefV4/Events/LapTimes.cs
+++ b/CrewChiefV4/Events/LapTimes.cs
@@ -406,7 +406,7 @@ namespace CrewChiefV4.Events
                             {
                                 // If requested, always play the laptime in hotlap/lone practice mode
                                 audioPlayer.playMessage(new QueuedMessage("laptime",
-                                        MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, this));
+                                        MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, this), 10);
                                 playedLapTime = true;
                             }
                             else if (((currentGameState.SessionData.SessionType == SessionType.Qualify || currentGameState.SessionData.SessionType == SessionType.Practice) && frequencyOfPlayerQualAndPracLapTimeReports > Utilities.random.NextDouble() * 10)
@@ -419,7 +419,7 @@ namespace CrewChiefV4.Events
                                 {
                                     gapFillerLapTime.maxPermittedQueueLengthForMessage = maxQueueLengthForRaceLapTimeReports;
                                 }
-                                audioPlayer.playMessage(gapFillerLapTime);
+                                audioPlayer.playMessage(gapFillerLapTime, 0);
                                 playedLapTime = true;
                             }
 
@@ -434,17 +434,17 @@ namespace CrewChiefV4.Events
                                         (isHotLappingOrLonePractice ? lastLapRating == LastLapRating.BEST_OVERALL : lastLapRating == LastLapRating.BEST_IN_CLASS 
                                             || deltaPlayerLastToSessionBestInClass <= TimeSpan.Zero))
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), 3);
                                     }
                                     else if (deltaPlayerLastToSessionBestInClass < TimeSpan.FromMilliseconds(50))
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage((isHotLappingOrLonePractice ? folderSelfLessThanATenthOffThePace : folderLessThanATenthOffThePace), 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage((isHotLappingOrLonePractice ? folderSelfLessThanATenthOffThePace : folderLessThanATenthOffThePace), 0, this), 3);
                                     }
                                     else if (deltaPlayerLastToSessionBestInClass < TimeSpan.MaxValue)
                                     {
                                         audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
                                             MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS),
-                                            isHotLappingOrLonePractice ? folderSelfGapOutroOffPace : folderGapOutroOffPace), 0, this));
+                                            isHotLappingOrLonePractice ? folderSelfGapOutroOffPace : folderGapOutroOffPace), 0, this), 3);
                                     }
                                     if (!GlobalBehaviourSettings.useOvalLogic &&
                                         practiceAndQualSectorReportsLapEnd && frequencyOfPracticeAndQualSectorDeltaReports > Utilities.random.NextDouble() * 10)
@@ -453,7 +453,7 @@ namespace CrewChiefV4.Events
                                             currentGameState.SessionData.LastSector2Time, lapAndSectorsComparisonData[2], currentGameState.SessionData.LastSector3Time, lapAndSectorsComparisonData[3], true, isHotLappingOrLonePractice /*selfPace*/);
                                         if (sectorMessageFragments.Count > 0)
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage("sectorsHotLap", sectorMessageFragments, 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage("sectorsHotLap", sectorMessageFragments, 0, this), 3);
                                             sectorsReportedForLap = true;
                                         }
                                     }
@@ -468,17 +468,17 @@ namespace CrewChiefV4.Events
                                         newGapToSecond = true;
                                         if (currentGameState.SessionData.SessionType == SessionType.Qualify)
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage(Position.folderPole, 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage(Position.folderPole, 0, this), 10);
                                         }
                                         else if (currentGameState.SessionData.SessionType == SessionType.Practice)
                                         {
                                             if (SoundCache.availableSounds.Contains(Position.folderDriverPositionIntro))
                                             {
-                                                audioPlayer.playMessage(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro, Position.folderStub + 1), 0, this));
+                                                audioPlayer.playMessage(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro, Position.folderStub + 1), 0, this), 5);
                                             }
                                             else
                                             {
-                                                audioPlayer.playMessage(new QueuedMessage(Position.folderStub + 1, 0, this));
+                                                audioPlayer.playMessage(new QueuedMessage(Position.folderStub + 1, 0, this), 5);
                                             }
                                         }
                                     }
@@ -501,7 +501,7 @@ namespace CrewChiefV4.Events
                                         {
                                             // delay this a bit...
                                             audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
-                                                MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), Utilities.random.Next(0, 8), this));
+                                                MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), Utilities.random.Next(0, 8), this), 5);
                                         }
                                     }
                                 }
@@ -511,7 +511,7 @@ namespace CrewChiefV4.Events
                                         (lastLapRating == LastLapRating.PERSONAL_BEST_STILL_SLOW || lastLapRating == LastLapRating.PERSONAL_BEST_CLOSE_TO_CLASS_LEADER ||
                                          lastLapRating == LastLapRating.PERSONAL_BEST_CLOSE_TO_OVERALL_LEADER))
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), 7);
                                     }
                                     // don't read this message if the rounded time gap is 0.0 seconds or it's more than 59 seconds
                                     // only play qual / prac deltas for Raceroom as the PCars data is inaccurate for sessions joined part way through
@@ -525,7 +525,7 @@ namespace CrewChiefV4.Events
                                     {
                                         // delay this a bit...
                                         audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
-                                            MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS), folderGapOutroOffPace), Utilities.random.Next(0, 8), this));
+                                            MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS), folderGapOutroOffPace), Utilities.random.Next(0, 8), this), 5);
                                     }
                                     if (!GlobalBehaviourSettings.useOvalLogic && 
                                         practiceAndQualSectorReportsLapEnd && frequencyOfPracticeAndQualSectorDeltaReports > Utilities.random.NextDouble() * 10)
@@ -534,7 +534,7 @@ namespace CrewChiefV4.Events
                                             currentGameState.SessionData.LastSector2Time, lapAndSectorsComparisonData[2], currentGameState.SessionData.LastSector3Time, lapAndSectorsComparisonData[3], true, false /*selfPace*/);
                                         if (sectorMessageFragments.Count > 0)
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage("sectorDeltas", sectorMessageFragments, 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage("sectorDeltas", sectorMessageFragments, 0, this), 5);
                                             sectorsReportedForLap = true;
                                         }
                                     }
@@ -550,32 +550,32 @@ namespace CrewChiefV4.Events
                                     {
                                         case LastLapRating.BEST_OVERALL:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
+                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 3);
                                             break;
                                         case LastLapRating.BEST_IN_CLASS:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRaceForClass, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
+                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRaceForClass, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 3);
                                             break;
                                         case LastLapRating.SETTING_CURRENT_PACE:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderSettingCurrentRacePace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
+                                            audioPlayer.playMessage(new QueuedMessage(folderSettingCurrentRacePace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 3);
                                             break;
                                         case LastLapRating.CLOSE_TO_CURRENT_PACE:
                                             // don't keep playing this one
                                             if (Utilities.random.NextDouble() < 0.5)
                                             {
                                                 playedLapMessage = true;
-                                                audioPlayer.playMessage(new QueuedMessage(folderMatchingCurrentRacePace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
+                                                audioPlayer.playMessage(new QueuedMessage(folderMatchingCurrentRacePace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 0);
                                             }
                                             break;
                                         case LastLapRating.PERSONAL_BEST_CLOSE_TO_OVERALL_LEADER:
                                         case LastLapRating.PERSONAL_BEST_CLOSE_TO_CLASS_LEADER:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
+                                            audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 0);
                                             break;
                                         case LastLapRating.PERSONAL_BEST_STILL_SLOW:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood);
+                                            audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood, 0);
                                             break;
                                         case LastLapRating.CLOSE_TO_OVERALL_LEADER:
                                         case LastLapRating.CLOSE_TO_CLASS_LEADER:
@@ -583,7 +583,7 @@ namespace CrewChiefV4.Events
                                             if (Utilities.random.NextDouble() < 0.2)
                                             {
                                                 playedLapMessage = true;
-                                                audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood);
+                                                audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood, 0);
                                             }
                                             break;
                                         default:
@@ -613,7 +613,7 @@ namespace CrewChiefV4.Events
                                     {
                                         QueuedMessage message = new QueuedMessage("sectorDeltas", sectorMessageFragments, 0, this);
                                         message.maxPermittedQueueLengthForMessage = maxQueueLengthForRaceSectorDeltaReports;
-                                        audioPlayer.playMessage(message);
+                                        audioPlayer.playMessage(message, 0);
                                         sectorsReportedForLap = true;
                                     }
                                 }
@@ -628,12 +628,12 @@ namespace CrewChiefV4.Events
                                     if (consistency == ConsistencyResult.CONSISTENT)
                                     {
                                         lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
-                                        audioPlayer.playMessage(new QueuedMessage(folderConsistentTimes, Utilities.random.Next(0, 8), this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderConsistentTimes, Utilities.random.Next(0, 8), this), 0);
                                     }
                                     else if (consistency == ConsistencyResult.IMPROVING)
                                     {
                                         lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
-                                        audioPlayer.playMessage(new QueuedMessage(folderImprovingTimes, Utilities.random.Next(0, 8), this));
+                                        audioPlayer.playMessage(new QueuedMessage(folderImprovingTimes, Utilities.random.Next(0, 8), this), 3);
                                     }
                                     else if (consistency == ConsistencyResult.WORSENING)
                                     {
@@ -648,7 +648,7 @@ namespace CrewChiefV4.Events
                                             // only complain about worsening laptimes if we've not overtaken anyone on this lap
                                             lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
 
-                                            audioPlayer.playMessage(new QueuedMessage(folderWorseningTimes, Utilities.random.Next(0, 8), this, new Dictionary<String, Object>()));
+                                            audioPlayer.playMessage(new QueuedMessage(folderWorseningTimes, Utilities.random.Next(0, 8), this, new Dictionary<String, Object>()), 3);
                                         }
                                     }
                                 }
@@ -696,7 +696,7 @@ namespace CrewChiefV4.Events
                         if (!GlobalBehaviourSettings.useOvalLogic && 
                             messageFragments.Count() > 0)
                         {
-                            audioPlayer.playMessage(new QueuedMessage("singleSectorDelta", messageFragments, Utilities.random.Next(2, 4), this));
+                            audioPlayer.playMessage(new QueuedMessage("singleSectorDelta", messageFragments, Utilities.random.Next(2, 4), this), 5);
                         }
                     }
                 }
@@ -1156,7 +1156,7 @@ namespace CrewChiefV4.Events
                             if (gapBehind.Seconds > 0 || gapBehind.Milliseconds > 50)
                             {
                                 // delay this a bit...
-                                audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
+                                audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeNotRaceGap",
                                     MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), 0, this));
                             }
                         }

--- a/CrewChiefV4/Events/LapTimes.cs
+++ b/CrewChiefV4/Events/LapTimes.cs
@@ -633,7 +633,7 @@ namespace CrewChiefV4.Events
                                     else if (consistency == ConsistencyResult.IMPROVING)
                                     {
                                         lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
-                                        audioPlayer.playMessage(new QueuedMessage(folderImprovingTimes, Utilities.random.Next(0, 8), this), 3);
+                                        audioPlayer.playMessage(new QueuedMessage(folderImprovingTimes, Utilities.random.Next(0, 8), this), 5);
                                     }
                                     else if (consistency == ConsistencyResult.WORSENING)
                                     {

--- a/CrewChiefV4/Events/Opponents.cs
+++ b/CrewChiefV4/Events/Opponents.cs
@@ -241,7 +241,7 @@ namespace CrewChiefV4.Events
                             if (opponentIdentifier != null)
                             {
                                 audioPlayer.playMessage(new QueuedMessage("opponent_tyre_change_" + opponentIdentifier.ToString(), MessageContents(opponentIdentifier,
-                                    folderIsNowOn, TyreMonitor.getFolderForTyreType(opponentData.CurrentTyres)), 0, this));
+                                    folderIsNowOn, TyreMonitor.getFolderForTyreType(opponentData.CurrentTyres)), 0, this), 5);
                             }
                         }
 
@@ -272,7 +272,7 @@ namespace CrewChiefV4.Events
                                     (currentGameState.SessionData.SessionType != SessionType.Race && frequencyOfOpponentPracticeAndQualLapTimes > 0))
                                 {
                                     audioPlayer.playMessage(new QueuedMessage("new_fastest_lap", MessageContents(folderNewFastestLapFor, opponentData,
-                                                TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this));
+                                                TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 3);
                                 }
                             }
                             else if ((currentGameState.SessionData.SessionType == SessionType.Race &&
@@ -288,7 +288,7 @@ namespace CrewChiefV4.Events
                                     // he's leading, and has recorded 3 or more laps, and this one's his fastest
                                     Console.WriteLine("Leader fast lap - this lap time = " + opponentData.LastLapTime + " session best = " + currentFastestLap);
                                     audioPlayer.playMessage(new QueuedMessage("leader_good_laptime", MessageContents(folderLeaderHasJustDoneA,
-                                            TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this));
+                                            TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 3);
                                 }
                                 else if (currentGameState.SessionData.ClassPosition > 1 && opponentData.ClassPosition == currentGameState.SessionData.ClassPosition - 1 &&
                                     (currentGameState.SessionData.SessionType == SessionType.Race || Utilities.random.Next(10) < frequencyOfOpponentPracticeAndQualLapTimes))
@@ -296,7 +296,7 @@ namespace CrewChiefV4.Events
                                     // he's ahead of us, and has recorded 3 or more laps, and this one's his fastest
                                     Console.WriteLine("Car ahead fast lap - this lap time = " + opponentData.LastLapTime + " session best = " + currentFastestLap);
                                     audioPlayer.playMessage(new QueuedMessage("car_ahead_good_laptime", MessageContents(folderTheCarAheadHasJustDoneA,
-                                           TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this));
+                                           TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 0);
                                 }
                                 else if (!currentGameState.isLast() && opponentData.ClassPosition == currentGameState.SessionData.ClassPosition + 1 &&
                                     (currentGameState.SessionData.SessionType == SessionType.Race || Utilities.random.Next(10) < frequencyOfOpponentPracticeAndQualLapTimes))
@@ -304,7 +304,7 @@ namespace CrewChiefV4.Events
                                     // he's behind us, and has recorded 3 or more laps, and this one's his fastest
                                     Console.WriteLine("Car behind fast lap - this lap time = " + opponentData.LastLapTime + " session best = " + currentFastestLap);
                                     audioPlayer.playMessage(new QueuedMessage("car_behind_good_laptime", MessageContents(folderTheCarBehindHasJustDoneA,
-                                            TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this));
+                                            TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 0);
                                 }
                             }
                         }
@@ -336,7 +336,7 @@ namespace CrewChiefV4.Events
                             }
                             if (AudioPlayer.canReadName(retiredDriver))
                             {
-                                audioPlayer.playMessage(new QueuedMessage("retirement", MessageContents(DriverNameHelper.getUsableDriverName(retiredDriver), folderHasJustRetired), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("retirement", MessageContents(DriverNameHelper.getUsableDriverName(retiredDriver), folderHasJustRetired), 0, this), 0);
                             }
                         }
                     }
@@ -347,7 +347,7 @@ namespace CrewChiefV4.Events
                             announcedRetirementsAndDQs.Add(dqDriver);
                             if (AudioPlayer.canReadName(dqDriver))
                             {
-                                audioPlayer.playMessage(new QueuedMessage("retirement", MessageContents(DriverNameHelper.getUsableDriverName(dqDriver), folderHasJustBeenDisqualified), 0, this));
+                                audioPlayer.playMessage(new QueuedMessage("retirement", MessageContents(DriverNameHelper.getUsableDriverName(dqDriver), folderHasJustBeenDisqualified), 0, this), 0);
                             }
                         }
                     }
@@ -371,7 +371,7 @@ namespace CrewChiefV4.Events
                                         Console.WriteLine("New car ahead: " + opponentName);
                                         audioPlayer.playMessage(new QueuedMessage("new_car_ahead", MessageContents(folderNextCarIs, opponentData),
                                             Utilities.random.Next(Position.maxSecondsToWaitBeforeReportingPass + 1, Position.maxSecondsToWaitBeforeReportingPass + 3), this,
-                                            new Dictionary<string, object> { { validationDriverAheadKey, opponentData.DriverRawName } }));
+                                            new Dictionary<string, object> { { validationDriverAheadKey, opponentData.DriverRawName } }), 7);
                                         nextCarAheadChangeMessage = currentGameState.Now.Add(TimeSpan.FromSeconds(30));
                                         onlyAnnounceOpponentAfter[opponentName] = currentGameState.Now.Add(waitBeforeAnnouncingSameOpponentAhead);
                                         lastNextCarAheadOpponentName = opponentName;
@@ -391,7 +391,7 @@ namespace CrewChiefV4.Events
                                 {
                                     Console.WriteLine("Lead change, current leader is " + name + " laps completed = " + currentGameState.SessionData.CompletedLaps);
                                     audioPlayer.playMessage(new QueuedMessage("new_leader", MessageContents(leader, folderIsNowLeading), 2, this,
-                                        new Dictionary<string, object> { { validationNewLeaderKey, name } }));
+                                        new Dictionary<string, object> { { validationNewLeaderKey, name } }), 3);
                                     nextLeadChangeMessage = currentGameState.Now.Add(TimeSpan.FromSeconds(60));
                                     lastLeaderAnnounced = name;
                                 }
@@ -407,7 +407,7 @@ namespace CrewChiefV4.Events
                     !Strategy.opponentsWhoWillExitCloseInFront.Contains(currentGameState.PitData.OpponentForLeaderPitting.DriverRawName))
                 {
                     audioPlayer.playMessage(new QueuedMessage("leader_is_pitting", MessageContents(folderTheLeader, currentGameState.PitData.OpponentForLeaderPitting,
-                        folderIsPitting), MessageContents(folderLeaderIsPitting), 0, this));
+                        folderIsPitting), MessageContents(folderLeaderIsPitting), 0, this), 3);
                     announcedPitters.Add(currentGameState.PitData.OpponentForLeaderPitting.DriverRawName);
                 }
 
@@ -416,7 +416,7 @@ namespace CrewChiefV4.Events
                     !Strategy.opponentsWhoWillExitCloseInFront.Contains(currentGameState.PitData.OpponentForCarAheadPitting.DriverRawName))
                 {
                     audioPlayer.playMessage(new QueuedMessage("car_in_front_is_pitting", MessageContents(currentGameState.PitData.OpponentForCarAheadPitting,
-                        folderAheadIsPitting), MessageContents(folderCarAheadIsPitting), 0, this));
+                        folderAheadIsPitting), MessageContents(folderCarAheadIsPitting), 0, this), 3);
                     announcedPitters.Add(currentGameState.PitData.OpponentForCarAheadPitting.DriverRawName);
                 }
 
@@ -425,7 +425,7 @@ namespace CrewChiefV4.Events
                     !Strategy.opponentsWhoWillExitCloseBehind.Contains(currentGameState.PitData.OpponentForCarBehindPitting.DriverRawName))
                 {
                     audioPlayer.playMessage(new QueuedMessage("car_behind_is_pitting", MessageContents(currentGameState.PitData.OpponentForCarBehindPitting,
-                        folderBehindIsPitting), MessageContents(folderCarBehindIsPitting), 0, this));
+                        folderBehindIsPitting), MessageContents(folderCarBehindIsPitting), 0, this), 3);
                     announcedPitters.Add(currentGameState.PitData.OpponentForCarBehindPitting.DriverRawName);
                 }
                 if (Strategy.opponentFrontToWatchForPitting != null && !announcedPitters.Contains(Strategy.opponentFrontToWatchForPitting))
@@ -437,7 +437,7 @@ namespace CrewChiefV4.Events
                             if (entry.Value.InPits)
                             {
                                 audioPlayer.playMessage(new QueuedMessage("car_is_pitting", MessageContents(entry.Value,
-                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting), 0, this));
+                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting), 0, this), 3);
                                 Strategy.opponentFrontToWatchForPitting = null;
                                 break;
                             }
@@ -453,7 +453,7 @@ namespace CrewChiefV4.Events
                             if (entry.Value.InPits)
                             {
                                 audioPlayer.playMessage(new QueuedMessage("car_is_pitting", MessageContents(entry.Value,
-                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting), 0, this));
+                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting), 0, this), 3);
                                 Strategy.opponentBehindToWatchForPitting = null;
                                 break;
                             }

--- a/CrewChiefV4/Events/OvertakingAidsMonitor.cs
+++ b/CrewChiefV4/Events/OvertakingAidsMonitor.cs
@@ -64,7 +64,7 @@ namespace CrewChiefV4.Events
                 {
                     if (drsAvailableOnThisLap && !hasUsedDrsOnThisLap)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("missed_available_drs", MessageContents(folderDontForgetDRS), 0, this));
+                        audioPlayer.playMessage(new QueuedMessage("missed_available_drs", MessageContents(folderDontForgetDRS), 0, this), 0);
                     }
                     drsAvailableOnThisLap = currentGameState.OvertakingAids.DrsAvailable;
                     hasUsedDrsOnThisLap = false;
@@ -87,7 +87,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", MessageContents(folderASecondOffDRSRange), 0, this));
+                            audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", MessageContents(folderASecondOffDRSRange), 0, this), 5);
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -96,7 +96,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", MessageContents(folderAFewTenthsOffDRSRange), 0, this));
+                            audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", MessageContents(folderAFewTenthsOffDRSRange), 0, this), 5);
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -111,7 +111,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, false /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("opponent_has_drs", MessageContents(folderGuyBehindHasDRS), 0, this));
+                            audioPlayer.playMessage(new QueuedMessage("opponent_has_drs", MessageContents(folderGuyBehindHasDRS), 0, this), 5);
                         }
                     }
                 }
@@ -123,7 +123,7 @@ namespace CrewChiefV4.Events
                 if (previousGameState.OvertakingAids.PushToPassEngaged && !currentGameState.OvertakingAids.PushToPassEngaged &&
                     currentGameState.OvertakingAids.PushToPassActivationsRemaining == 0)
                 {
-                    audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", MessageContents(folderNoActivationsRemaining), 0, this));
+                    audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", MessageContents(folderNoActivationsRemaining), 0, this), 5);
                     pushToPassActivationsRemaining = 0;
                 }
                 else if (previousGameState.OvertakingAids.PushToPassWaitTimeLeft > 0 && currentGameState.OvertakingAids.PushToPassWaitTimeLeft == 0)
@@ -131,18 +131,18 @@ namespace CrewChiefV4.Events
                     if (currentGameState.OvertakingAids.PushToPassActivationsRemaining == 1)
                     {
                         audioPlayer.playMessage(new QueuedMessage("one_push_to_pass_remaining", MessageContents(
-                            folderPushToPassNowAvailable, folderOneActivationRemaining), 0, this));
+                            folderPushToPassNowAvailable, folderOneActivationRemaining), 0, this), 7);
                         pushToPassActivationsRemaining = 1;
                     }
                     else if (currentGameState.OvertakingAids.PushToPassActivationsRemaining > 0)
                     {
                         audioPlayer.playMessage(new QueuedMessage("push_to_pass_remaining", MessageContents(folderPushToPassNowAvailable,
-                            currentGameState.OvertakingAids.PushToPassActivationsRemaining, folderActivationsRemaining), 0, this));
+                            currentGameState.OvertakingAids.PushToPassActivationsRemaining, folderActivationsRemaining), 0, this), 2);
                         pushToPassActivationsRemaining = currentGameState.OvertakingAids.PushToPassActivationsRemaining;
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", MessageContents(folderNoActivationsRemaining), 0, this));
+                        audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", MessageContents(folderNoActivationsRemaining), 0, this), 5);
                         pushToPassActivationsRemaining = 0;
                     }
                 }

--- a/CrewChiefV4/Events/OvertakingAidsMonitor.cs
+++ b/CrewChiefV4/Events/OvertakingAidsMonitor.cs
@@ -87,7 +87,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", MessageContents(folderASecondOffDRSRange), 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", MessageContents(folderASecondOffDRSRange), 0, this), 10);
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -96,7 +96,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", MessageContents(folderAFewTenthsOffDRSRange), 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", MessageContents(folderAFewTenthsOffDRSRange), 0, this), 10);
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -111,7 +111,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, false /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("opponent_has_drs", MessageContents(folderGuyBehindHasDRS), 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage("opponent_has_drs", MessageContents(folderGuyBehindHasDRS), 0, this), 10);
                         }
                     }
                 }

--- a/CrewChiefV4/Events/Penalties.cs
+++ b/CrewChiefV4/Events/Penalties.cs
@@ -160,9 +160,9 @@ namespace CrewChiefV4.Events
                 {
                     lapsCompleted = currentGameState.SessionData.CompletedLaps;
                     // this is a new penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyDriveThrough, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyDriveThrough, 0, this), 10);
                     // queue a '3 laps to serve penalty' message - this might not get played
-                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 20, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 20, this), 10);
                     // we don't already have a penalty
                     if (penaltyLap == -1 || !hasOutstandingPenalty)
                     {
@@ -180,9 +180,9 @@ namespace CrewChiefV4.Events
                 {
                     lapsCompleted = currentGameState.SessionData.CompletedLaps;
                     // this is a new penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyStopGo, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyStopGo, 0, this), 10);
                     // queue a '3 laps to serve penalty' message - this might not get played
-                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 20, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 20, this), 10);
                     // we don't already have a penalty
                     if (penaltyLap == -1 || !hasOutstandingPenalty)
                     {
@@ -200,7 +200,7 @@ namespace CrewChiefV4.Events
                     (currentGameState.PenaltiesData.HasStopAndGo || currentGameState.PenaltiesData.HasDriveThrough))
                 {
                     // we've exited the pits but there's still an outstanding penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 3, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 3, this), 10);
                     playedNotServedPenalty = true;
                 } 
                 else if (currentGameState.SessionData.IsNewLap && (currentGameState.PenaltiesData.HasStopAndGo || currentGameState.PenaltiesData.HasDriveThrough))
@@ -213,36 +213,36 @@ namespace CrewChiefV4.Events
                         // run out of laps, and not in the pitlane
                         if (!audioPlayer.playRant("disqualified_rant", MessageContents(folderDisqualified)))
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderDisqualified, 5, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderDisqualified, 5, this), 10);
                         }
                     }
                     else if (lapsCompleted - penaltyLap == 2 && currentGameState.PenaltiesData.HasDriveThrough)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeDriveThrough, pitstopDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeDriveThrough, pitstopDelay, this), 10);
                     }
                     else if (lapsCompleted - penaltyLap == 2 && currentGameState.PenaltiesData.HasStopAndGo)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeStopGo, pitstopDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeStopGo, pitstopDelay, this), 10);
                     }
                     else if (lapsCompleted - penaltyLap == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay, this), 10);
                     }
                 }
                 else if (!playedPitNow && currentGameState.SessionData.SectorNumber == 3 && currentGameState.PenaltiesData.HasStopAndGo && lapsCompleted - penaltyLap == 2)
                 {
                     playedPitNow = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderPitNowStopGo, 6, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderPitNowStopGo, 6, this), 10);
                 }
                 else if (!playedPitNow && currentGameState.SessionData.SectorNumber == 3 && currentGameState.PenaltiesData.HasDriveThrough && lapsCompleted - penaltyLap == 2)
                 {
                     playedPitNow = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderPitNowDriveThrough, 6, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderPitNowDriveThrough, 6, this), 10);
                 }
                 else if (!playedTimePenaltyMessage && currentGameState.PenaltiesData.HasTimeDeduction)
                 {
                     playedTimePenaltyMessage = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderTimePenalty, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderTimePenalty, 0, this), 10);
                 }
             }
             else if (currentGameState.PositionAndMotionData.CarSpeed > 1 && playCutTrackWarnings && 
@@ -260,7 +260,7 @@ namespace CrewChiefV4.Events
                     {
                         if (currentGameState.SessionData.SessionType == SessionType.Race)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderCutTrackInRace, 2, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderCutTrackInRace, 2, this), 3);
                         }
                         else if (!playedTrackCutWarningInPracticeOrQualOnThisLap)
                         {
@@ -269,11 +269,11 @@ namespace CrewChiefV4.Events
                                 && currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance != -1.0f
                                 && currentGameState.PositionAndMotionData.DistanceRoundTrack > currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 2, this));
+                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 2, this), 10);
                             }
                             else
                             {
-                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 2, this));
+                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 2, this), 10);
                             }
                             playedTrackCutWarningInPracticeOrQualOnThisLap = true;
                         }
@@ -297,11 +297,11 @@ namespace CrewChiefV4.Events
                         && currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance != -1.0f
                         && currentGameState.PositionAndMotionData.DistanceRoundTrack > currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 2, this));
+                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 2, this), 10);
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 2, this));
+                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 2, this), 10);
                     }
                     clearPenaltyState();
                 }
@@ -316,9 +316,9 @@ namespace CrewChiefV4.Events
                 {
                     lapsCompleted = currentGameState.SessionData.CompletedLaps;
                     // this is a new penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderYouHavePenalty, Utilities.random.Next(3, 7), this));
+                    audioPlayer.playMessage(new QueuedMessage(folderYouHavePenalty, Utilities.random.Next(3, 7), this), 10);
                     // queue a '3 laps to serve penalty' message - this might not get played
-                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, Utilities.random.Next(10, 20), this));
+                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, Utilities.random.Next(10, 20), this), 10);
                     // we don't already have a penalty
                     if (penaltyLap == -1 || !hasOutstandingPenalty)
                     {
@@ -331,7 +331,7 @@ namespace CrewChiefV4.Events
                     currentGameState.PenaltiesData.NumPenalties > 0)
                 {
                     // we've exited the pits but there's still an outstanding penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 3, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 3, this), 10);
                     playedNotServedPenalty = true;
                 }
                 else if (currentGameState.SessionData.IsNewLap && currentGameState.PenaltiesData.NumPenalties > 0)
@@ -342,18 +342,18 @@ namespace CrewChiefV4.Events
                     if (lapsCompleted - penaltyLap >= 2 && !currentGameState.PitData.InPitlane)
                     {
                         // run out of laps, an not in the pitlane
-                        audioPlayer.playMessage(new QueuedMessage(folderYouStillHavePenalty, 5, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderYouStillHavePenalty, 5, this), 10);
                     }
                     else if (lapsCompleted - penaltyLap == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay, this), 10);
                     }
                 }
             }
             else if (currentGameState.PenaltiesData.PossibleTrackLimitsViolation && playCutTrackWarnings && !warnedOfPossibleTrackLimitsViolationOnThisLap)
             {
                 warnedOfPossibleTrackLimitsViolationOnThisLap = true;
-                audioPlayer.playMessage(new QueuedMessage(folderPossibleTrackLimitsViolation, 2 + Utilities.random.Next(3), this));
+                audioPlayer.playMessage(new QueuedMessage(folderPossibleTrackLimitsViolation, 2 + Utilities.random.Next(3), this), 0);
             }
             else
             {
@@ -366,7 +366,7 @@ namespace CrewChiefV4.Events
                 (previousGameState.PenaltiesData.NumPenalties > currentGameState.PenaltiesData.NumPenalties &&
                 (CrewChief.gameDefinition.gameEnum == GameEnum.RF1 || CrewChief.gameDefinition.gameEnum == GameEnum.RF2_64BIT))))
             {
-                audioPlayer.playMessage(new QueuedMessage(folderPenaltyServed, 0, this));
+                audioPlayer.playMessage(new QueuedMessage(folderPenaltyServed, 0, this), 10);
             }            
         }
 

--- a/CrewChiefV4/Events/PitStops.cs
+++ b/CrewChiefV4/Events/PitStops.cs
@@ -275,7 +275,7 @@ namespace CrewChiefV4.Events
                         messageContents.Add(MessageFragment.Text(folderMetres));
                         QueuedMessage firstPitCountdown = new QueuedMessage("pit_entry_to_box_distance_warning", messageContents, 0, this);
                         firstPitCountdown.expiryTime = (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) + 2000;
-                        audioPlayer.playMessage(firstPitCountdown);
+                        audioPlayer.playMessage(firstPitCountdown, 10);
 
                         playedMoreThan150MetreWarning = true;
                     }
@@ -416,26 +416,26 @@ namespace CrewChiefV4.Events
                                 mandatoryStopBoxThisLap = true;
                                 if (mandatoryTyreChangeTyreType == TyreType.Prime)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitPrimesThisLap, Utilities.random.Next(0, 10), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitPrimesThisLap, Utilities.random.Next(0, 10), this), 10);
                                 }
                                 else if (mandatoryTyreChangeTyreType == TyreType.Option)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitOptionsThisLap, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitOptionsThisLap, Utilities.random.Next(0, 20), this), 10);
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLap, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLap, Utilities.random.Next(0, 20), this), 10);
                                 }
                             }
                             else if (minDistanceOnCurrentTyre > 0 && currentGameState.SessionData.CompletedLaps == minDistanceOnCurrentTyre)
                             {
                                 if (mandatoryTyreChangeTyreType == TyreType.Prime)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsCanNowFitPrimes, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsCanNowFitPrimes, Utilities.random.Next(0, 20), this), 5);
                                 }
                                 else if (mandatoryTyreChangeTyreType == TyreType.Option)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsCanNowFitOptions, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsCanNowFitOptions, Utilities.random.Next(0, 20), this), 5);
                                 }
                             }
                         }
@@ -446,7 +446,7 @@ namespace CrewChiefV4.Events
                             // so we play it 1 lap before the window opens
                             if (enableWindowWarnings)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpening, Utilities.random.Next(0, 20), this));
+                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpening, Utilities.random.Next(0, 20), this), 10);
                             }
                         }
                         else if (pitWindowOpenLap > 0 && currentGameState.SessionData.CompletedLaps == pitWindowOpenLap)
@@ -455,14 +455,14 @@ namespace CrewChiefV4.Events
                             if (enableWindowWarnings)
                             {
                                 audioPlayer.setBackgroundSound(AudioPlayer.dtmPitWindowOpenBackground);
-                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen, 0, this), 10);
                             }
                         }
                         else if (pitWindowClosedLap > 0 && currentGameState.SessionData.CompletedLaps == pitWindowClosedLap - 1)
                         {
                             if (enableWindowWarnings)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowClosing, Utilities.random.Next(0, 20), this));
+                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowClosing, Utilities.random.Next(0, 20), this), 10);
                             }
                             if (currentGameState.PitData.PitWindow != PitWindow.Completed && !currentGameState.PitData.InPitlane &&
                                 currentGameState.PitData.PitWindow != PitWindow.StopInProgress)
@@ -470,15 +470,15 @@ namespace CrewChiefV4.Events
                                 playBoxNowMessage = true;
                                 if (mandatoryTyreChangeTyreType == TyreType.Prime)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitPrimesThisLap, Utilities.random.Next(0, 10), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitPrimesThisLap, Utilities.random.Next(0, 10), this), 10);
                                 }
                                 else if (mandatoryTyreChangeTyreType == TyreType.Option)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitOptionsThisLap, Utilities.random.Next(0, 10), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitOptionsThisLap, Utilities.random.Next(0, 10), this), 10);
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLap, Utilities.random.Next(0, 10), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLap, Utilities.random.Next(0, 10), this), 10);
                                 }
                             }
                         }
@@ -493,7 +493,7 @@ namespace CrewChiefV4.Events
                             if (enableWindowWarnings)
                             {
                                 audioPlayer.setBackgroundSound(AudioPlayer.dtmPitWindowClosedBackground);
-                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowClosed, 0, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowClosed, 0, this), 10);
                             }
                         }
                     }
@@ -514,7 +514,7 @@ namespace CrewChiefV4.Events
                                 mandatoryStopBoxThisLap = true;
                                 if (enableWindowWarnings)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLapTooLate, 0, this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLapTooLate, 0, this), 10);
                                 }
                             }
                             else if (playPitThisLap && currentGameState.SessionData.PlayerLapTimeSessionBest + 10 < timeLeftToPit &&
@@ -526,15 +526,15 @@ namespace CrewChiefV4.Events
                                 mandatoryStopBoxThisLap = true;
                                 if (mandatoryTyreChangeTyreType == TyreType.Prime)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitPrimesThisLap, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitPrimesThisLap, Utilities.random.Next(0, 20), this), 10);
                                 }
                                 else if (mandatoryTyreChangeTyreType == TyreType.Option)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitOptionsThisLap, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsFitOptionsThisLap, Utilities.random.Next(0, 20), this), 10);
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLap, Utilities.random.Next(0, 20), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitThisLap, Utilities.random.Next(0, 20), this), 10);
                                 }
                             }
                         }
@@ -548,7 +548,7 @@ namespace CrewChiefV4.Events
                         play2minOpenWarning = false;
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen, 0, this), 10);
                         }
                     }
                     else if (play1minOpenWarning && currentGameState.SessionData.SessionTimeRemaining > 0 &&
@@ -558,7 +558,7 @@ namespace CrewChiefV4.Events
                         play2minOpenWarning = false;
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen1Min, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen1Min, 0, this), 3);
                         }
                     }
                     else if (play2minOpenWarning && currentGameState.SessionData.SessionTimeRemaining > 0 &&
@@ -567,7 +567,7 @@ namespace CrewChiefV4.Events
                         play2minOpenWarning = false;
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen2Min, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen2Min, 0, this), 2);
                         }
                     }
                     else if (pitWindowClosedTime > 0 && playClosedNow && currentGameState.SessionData.SessionTimeRemaining > 0 &&
@@ -585,7 +585,7 @@ namespace CrewChiefV4.Events
                         }
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowClosed, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowClosed, 0, this), 10);
                         }
                     }
                     else if (pitWindowClosedTime > 0 && play1minCloseWarning && currentGameState.SessionData.SessionTimeRemaining > 0 &&
@@ -595,7 +595,7 @@ namespace CrewChiefV4.Events
                         play2minCloseWarning = false;
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowCloses1min, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowCloses1min, 0, this), 10);
                         }
                     }
                     else if (pitWindowClosedTime > 0 && play2minCloseWarning && currentGameState.SessionData.SessionTimeRemaining > 0 &&
@@ -604,7 +604,7 @@ namespace CrewChiefV4.Events
                         play2minCloseWarning = false;
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowCloses2min, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowCloses2min, 0, this), 10);
                         }
                     }
 
@@ -616,7 +616,7 @@ namespace CrewChiefV4.Events
                         playBoxNowMessage = false;
                         // pit entry is right at sector 3 timing line, play message part way through sector 2 to give us time to pit
                         int messageDelay = currentGameState.SessionData.PlayerBestSector2Time > 0 ? (int)(currentGameState.SessionData.PlayerBestSector2Time * 0.7) : 15;
-                        audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitNow, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitNow, messageDelay, this), 10);
                     }
 
                     if (playBoxNowMessage && currentGameState.SessionData.SectorNumber == 3)
@@ -627,15 +627,15 @@ namespace CrewChiefV4.Events
                         {                            
                             if (mandatoryTyreChangeTyreType == TyreType.Prime)
                             {
-                                audioPlayer.playMessage(new QueuedMessage("box_now_for_primes", MessageContents(folderMandatoryPitStopsPitNow, folderMandatoryPitStopsPrimeTyres), 3, this));
+                                audioPlayer.playMessage(new QueuedMessage("box_now_for_primes", MessageContents(folderMandatoryPitStopsPitNow, folderMandatoryPitStopsPrimeTyres), 3, this), 10);
                             }
                             else if (mandatoryTyreChangeTyreType == TyreType.Option)
                             {
-                                audioPlayer.playMessage(new QueuedMessage("box_now_for_options", MessageContents(folderMandatoryPitStopsPitNow, folderMandatoryPitStopsOptionTyres), 3, this));
+                                audioPlayer.playMessage(new QueuedMessage("box_now_for_options", MessageContents(folderMandatoryPitStopsPitNow, folderMandatoryPitStopsOptionTyres), 3, this), 10);
                             }
                             else
                             {
-                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitNow, 3, this));
+                                audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitNow, 3, this), 10);
                             }
                         }
                     }
@@ -666,7 +666,7 @@ namespace CrewChiefV4.Events
                     {
                         if (!previousGameState.PitData.PitStallOccupied && currentGameState.PitData.PitStallOccupied)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderPitStallOccupied, Utilities.random.Next(1, 3), this));
+                            audioPlayer.playMessage(new QueuedMessage(folderPitStallOccupied, Utilities.random.Next(1, 3), this), 10);
                             warnedAboutOccupiedPitOnThisLap = true;
                         }
                         if (currentGameState.SessionData.SectorNumber == 3 &&
@@ -677,20 +677,20 @@ namespace CrewChiefV4.Events
                             {
                                 if (!warnedAboutOccupiedPitOnThisLap)
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderPitStallOccupied, Utilities.random.Next(1, 3), this));
+                                    audioPlayer.playMessage(new QueuedMessage(folderPitStallOccupied, Utilities.random.Next(1, 3), this), 10);
                                     warnedAboutOccupiedPitOnThisLap = true;
                                 }
                             }
                             else
                             {
-                                audioPlayer.playMessage(new QueuedMessage(folderPitCrewReady, Utilities.random.Next(1, 3), this));
+                                audioPlayer.playMessage(new QueuedMessage(folderPitCrewReady, Utilities.random.Next(1, 3), this), 10);
                             }
                         }
                     }
                     else if (!previousGameState.PitData.IsPitCrewReady
                         && currentGameState.PitData.IsPitCrewReady)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPitCrewReady, Utilities.random.Next(1, 3), this));
+                        audioPlayer.playMessage(new QueuedMessage(folderPitCrewReady, Utilities.random.Next(1, 3), this), 10);
                     }
                     if (!previousGameState.PitData.IsPitCrewDone
                         && currentGameState.PitData.IsPitCrewDone)
@@ -714,7 +714,7 @@ namespace CrewChiefV4.Events
                         && (currentGameState.Now - timeOfPitRequestOrCancel).TotalSeconds > minSecondsBetweenPitRequestCancel)
                     {
                         timeOfPitRequestOrCancel = currentGameState.Now;
-                        audioPlayer.playMessage(new QueuedMessage(folderPitStopRequestCancelled, Utilities.random.Next(1, 3), this));
+                        audioPlayer.playMessage(new QueuedMessage(folderPitStopRequestCancelled, Utilities.random.Next(1, 3), this), 10);
                     }
                 }
                 else if ((CrewChief.gameDefinition.gameEnum == GameEnum.PCARS2 || CrewChief.gameDefinition.gameEnum == GameEnum.PCARS2_NETWORK) &&

--- a/CrewChiefV4/Events/PitStops.cs
+++ b/CrewChiefV4/Events/PitStops.cs
@@ -567,7 +567,7 @@ namespace CrewChiefV4.Events
                         play2minOpenWarning = false;
                         if (enableWindowWarnings)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen2Min, 0, this), 2);
+                            audioPlayer.playMessage(new QueuedMessage(folderMandatoryPitStopsPitWindowOpen2Min, 0, this), 10);
                         }
                     }
                     else if (pitWindowClosedTime > 0 && playClosedNow && currentGameState.SessionData.SessionTimeRemaining > 0 &&

--- a/CrewChiefV4/Events/Position.cs
+++ b/CrewChiefV4/Events/Position.cs
@@ -275,7 +275,7 @@ namespace CrewChiefV4.Events
                             Dictionary<String, Object> validationData = new Dictionary<String, Object>();
                             validationData.Add(positionValidationKey, currentGameState.SessionData.ClassPosition);
                             QueuedMessage overtakingMessage = new QueuedMessage(folderOvertaking, 0, this, validationData);
-                            audioPlayer.playMessage(overtakingMessage, PearlsOfWisdom.PearlType.GOOD, 0);
+                            audioPlayer.playMessage(overtakingMessage, PearlsOfWisdom.PearlType.GOOD, 0, 10);
                             reported = true;
                         }
                     }
@@ -317,7 +317,7 @@ namespace CrewChiefV4.Events
                             Dictionary<String, Object> validationData = new Dictionary<String, Object>();
                             validationData.Add(positionValidationKey, currentGameState.SessionData.ClassPosition);
                             QueuedMessage beingOvertakenMessage = new QueuedMessage(folderBeingOvertaken, 0, this, validationData);
-                            audioPlayer.playMessage(new QueuedMessage(folderBeingOvertaken, 0, this, validationData), PearlsOfWisdom.PearlType.BAD, 0);
+                            audioPlayer.playMessage(new QueuedMessage(folderBeingOvertaken, 0, this, validationData), PearlsOfWisdom.PearlType.BAD, 0, 10);
                             reported = true;
                         }
                     }
@@ -381,20 +381,20 @@ namespace CrewChiefV4.Events
                     {
                         if (currentGameState.SessionData.ClassPosition > currentGameState.SessionData.SessionStartClassPosition + 4)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderTerribleStart, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderTerribleStart, 0, this), 10);
                         }
                         else if (currentGameState.SessionData.ClassPosition > currentGameState.SessionData.SessionStartClassPosition + 1)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderBadStart, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderBadStart, 0, this), 10);
                         }
                         else if (!isLast && (currentGameState.SessionData.ClassPosition == 1 || currentGameState.SessionData.ClassPosition < currentGameState.SessionData.SessionStartClassPosition - 1))
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderGoodStart, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderGoodStart, 0, this), 10);
                         }
                         else if (!isLast && Utilities.random.NextDouble() > 0.6)
                         {
                             // only play the OK start message sometimes
-                            audioPlayer.playMessage(new QueuedMessage(folderOKStart, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderOKStart, 0, this), 10);
                         }
                     }
                 }
@@ -460,7 +460,7 @@ namespace CrewChiefV4.Events
                             CrewChief.gameDefinition.gameEnum == GameEnum.ASSETTO_64BIT ? 1 : 0;
                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("getPositionMessages", new Object[] { 
                             currentPosition }, this);
-                        audioPlayer.playMessage(new QueuedMessage("position", delayedMessageEvent, delaySeconds, null), pearlType, pearlLikelihood);
+                        audioPlayer.playMessage(new QueuedMessage("position", delayedMessageEvent, delaySeconds, null), pearlType, pearlLikelihood, 10);
                         lapNumberAtLastMessage = currentGameState.SessionData.CompletedLaps;
                     }
                 }

--- a/CrewChiefV4/Events/Position.cs
+++ b/CrewChiefV4/Events/Position.cs
@@ -381,20 +381,20 @@ namespace CrewChiefV4.Events
                     {
                         if (currentGameState.SessionData.ClassPosition > currentGameState.SessionData.SessionStartClassPosition + 4)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderTerribleStart, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderTerribleStart, 0, this), 5);
                         }
                         else if (currentGameState.SessionData.ClassPosition > currentGameState.SessionData.SessionStartClassPosition + 1)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderBadStart, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderBadStart, 0, this), 5);
                         }
                         else if (!isLast && (currentGameState.SessionData.ClassPosition == 1 || currentGameState.SessionData.ClassPosition < currentGameState.SessionData.SessionStartClassPosition - 1))
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderGoodStart, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderGoodStart, 0, this), 5);
                         }
                         else if (!isLast && Utilities.random.NextDouble() > 0.6)
                         {
                             // only play the OK start message sometimes
-                            audioPlayer.playMessage(new QueuedMessage(folderOKStart, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderOKStart, 0, this), 5);
                         }
                     }
                 }

--- a/CrewChiefV4/Events/PushNow.cs
+++ b/CrewChiefV4/Events/PushNow.cs
@@ -237,19 +237,19 @@ namespace CrewChiefV4.Events
                     // going flat out, we're going to catch the guy ahead us before the end
                     if (currentGameState.SessionData.ClassPosition == 2)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetWin, 0, this), 3);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetWin, 0, this), 5);
                     }
                     else if (currentGameState.SessionData.ClassPosition == 3)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetSecond, 0, this), 3);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetSecond, 0, this), 5);
                     }
                     else if (currentGameState.SessionData.ClassPosition == 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetThird, 0, this), 3);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetThird, 0, this), 5);
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToImprove, 0, this), 3);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToImprove, 0, this), 5);
                     }
                     return true;
                 }

--- a/CrewChiefV4/Events/PushNow.cs
+++ b/CrewChiefV4/Events/PushNow.cs
@@ -237,19 +237,19 @@ namespace CrewChiefV4.Events
                     // going flat out, we're going to catch the guy ahead us before the end
                     if (currentGameState.SessionData.ClassPosition == 2)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetWin, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetWin, 0, this), 3);
                     }
                     else if (currentGameState.SessionData.ClassPosition == 3)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetSecond, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetSecond, 0, this), 3);
                     }
                     else if (currentGameState.SessionData.ClassPosition == 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetThird, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetThird, 0, this), 3);
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToImprove, 0, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToImprove, 0, this), 3);
                     }
                     return true;
                 }
@@ -263,7 +263,7 @@ namespace CrewChiefV4.Events
                     // even with us going flat out, the guy behind is going to catch us before the end
                     Console.WriteLine("Might lose this position. Player best lap = " + currentGameState.SessionData.PlayerLapTimeSessionBest.ToString("0.000") + " laps left = " + numLapsLeft +
                         " opponent best lap = " + opponentBehindBestLap.ToString("0.000") + " time delta = " + currentGameState.SessionData.TimeDeltaBehind.ToString("0.000"));
-                    audioPlayer.playMessage(new QueuedMessage(folderPushToHoldPosition, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderPushToHoldPosition, 0, this), 3);
                     return true;
                 }
             }

--- a/CrewChiefV4/Events/RaceTime.cs
+++ b/CrewChiefV4/Events/RaceTime.cs
@@ -156,16 +156,16 @@ namespace CrewChiefV4.Events
                         if (currentGameState.SessionData.ClassPosition == 1)
                         {
                             // don't add a pearl here - the audio clip already contains encouragement
-                            audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 0, this), pearlType, 0);
+                            audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 0, this), pearlType, 0, 5);
                         }
                         else if (currentGameState.SessionData.ClassPosition < 4)
                         {
                             // don't add a pearl here - the audio clip already contains encouragement
-                            audioPlayer.playMessage(new QueuedMessage(folderLastLapPodium, 0, this), pearlType, 0);
+                            audioPlayer.playMessage(new QueuedMessage(folderLastLapPodium, 0, this), pearlType, 0, 5);
                         }
                         else
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderLastLap, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderLastLap, 0, this), 5);
                         }
                     }
                 }
@@ -195,7 +195,7 @@ namespace CrewChiefV4.Events
                     {
                         // don't play the chequered flag message in race sessions
                         audioPlayer.playMessage(new QueuedMessage("session_complete",
-                            MessageContents(folder0mins, Position.folderStub + currentGameState.SessionData.ClassPosition), 0, this));
+                            MessageContents(folder0mins, Position.folderStub + currentGameState.SessionData.ClassPosition), 0, this), 10);
                     }
                 } 
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played2mins && timeLeft / 60 < 2 && timeLeft / 60 > 1.9)
@@ -207,7 +207,7 @@ namespace CrewChiefV4.Events
                     played20mins = true;
                     playedHalfWayHome = true;
                     audioPlayer.suspendPearlsOfWisdom();
-                    audioPlayer.playMessage(new QueuedMessage(folder2mins, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folder2mins, 0, this), 10);
                 } if (currentGameState.SessionData.SessionRunningTime > 60 && !played5mins && timeLeft / 60 < 5 && timeLeft / 60 > 4.9)
                 {
                     played5mins = true;
@@ -218,16 +218,16 @@ namespace CrewChiefV4.Events
                     if (currentGameState.SessionData.SessionType == SessionType.Race && currentGameState.SessionData.ClassPosition == 1)
                     {
                         // don't add a pearl here - the audio clip already contains encouragement
-                        audioPlayer.playMessage(new QueuedMessage(folder5minsLeading, 0, this), pearlType, 0);
+                        audioPlayer.playMessage(new QueuedMessage(folder5minsLeading, 0, this), pearlType, 0, 5);
                     }
                     else if (currentGameState.SessionData.SessionType == SessionType.Race && currentGameState.SessionData.ClassPosition < 4)
                     {
                         // don't add a pearl here - the audio clip already contains encouragement
-                        audioPlayer.playMessage(new QueuedMessage(folder5minsPodium, 0, this), pearlType, 0);
+                        audioPlayer.playMessage(new QueuedMessage(folder5minsPodium, 0, this), pearlType, 0, 5);
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folder5mins, 0, this), pearlType, 0.7);
+                        audioPlayer.playMessage(new QueuedMessage(folder5mins, 0, this), pearlType, 0.7, 5);
                     }
                 }
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played10mins && timeLeft / 60 < 10 && timeLeft / 60 > 9.9)
@@ -235,25 +235,25 @@ namespace CrewChiefV4.Events
                     played10mins = true;
                     played15mins = true;
                     played20mins = true;
-                    audioPlayer.playMessage(new QueuedMessage(folder10mins, 0, this), pearlType, 0.7);
+                    audioPlayer.playMessage(new QueuedMessage(folder10mins, 0, this), pearlType, 0.7, 3);
                 }
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played15mins && timeLeft / 60 < 15 && timeLeft / 60 > 14.9)
                 {
                     played15mins = true;
                     played20mins = true;
-                    audioPlayer.playMessage(new QueuedMessage(folder15mins, 0, this), pearlType, 0.7);
+                    audioPlayer.playMessage(new QueuedMessage(folder15mins, 0, this), pearlType, 0.7, 3);
                 }
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played20mins && timeLeft / 60 < 20 && timeLeft / 60 > 19.9)
                 {
                     played20mins = true;
-                    audioPlayer.playMessage(new QueuedMessage(folder20mins, 0, this), pearlType, 0.7);
+                    audioPlayer.playMessage(new QueuedMessage(folder20mins, 0, this), pearlType, 0.7, 3);
                 }
                 else if (currentGameState.SessionData.SessionType == SessionType.Race &&
                     currentGameState.SessionData.SessionRunningTime > 60 && !playedHalfWayHome && timeLeft > 0 && timeLeft < halfTime)
                 {
                     // this one sounds weird in practice and qual sessions, so skip it
                     playedHalfWayHome = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderHalfWayHome, 0, this), pearlType, 0.7);
+                    audioPlayer.playMessage(new QueuedMessage(folderHalfWayHome, 0, this), pearlType, 0.7, 3);
                 }
             }
         }

--- a/CrewChiefV4/Events/SessionEndMessages.cs
+++ b/CrewChiefV4/Events/SessionEndMessages.cs
@@ -113,24 +113,24 @@ namespace CrewChiefV4.Events
                     if (!playedRant)
                     {
                         audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                            Penalties.folderDisqualified), 0, null));
+                            Penalties.folderDisqualified), 0, null), 10);
                     }                    
                 }
                 else if (isDNF)
                 {
                     // TODO: different msg probably.
                     audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier,
-                        AbstractEvent.MessageContents(folderFinishedRaceLast), 0, null));
+                        AbstractEvent.MessageContents(folderFinishedRaceLast), 0, null), 10);
                 }
                 else if (position == 1)
                 {
                     audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                        folderWonRace), 0, null));
+                        folderWonRace), 0, null), 10);
                 }
                 else if (position < 4)
                 {
                     audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                        folderPodiumFinish), 0, null));
+                        folderPodiumFinish), 0, null), 10);
                 }
                 else if (position >= 4 && !isLast)
                 {
@@ -141,7 +141,7 @@ namespace CrewChiefV4.Events
                          (startPosition - position >= 6)))
                     {
                         audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                                Position.folderStub + position, folderGoodFinish), 0, null));
+                                Position.folderStub + position, folderGoodFinish), 0, null), 10);
                     }
                     else
                     {
@@ -156,7 +156,7 @@ namespace CrewChiefV4.Events
                         if (!playedRant)
                         {
                             audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                                Position.folderStub + position, folderFinishedRace), 0, null));
+                                Position.folderStub + position, folderFinishedRace), 0, null), 10);
                         }
                     }
                 }
@@ -170,7 +170,7 @@ namespace CrewChiefV4.Events
                     if (!playedRant)
                     {
                         audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier,
-                            AbstractEvent.MessageContents(folderFinishedRaceLast), 0, null));
+                            AbstractEvent.MessageContents(folderFinishedRaceLast), 0, null), 10);
                     }
                 }
             }
@@ -183,7 +183,7 @@ namespace CrewChiefV4.Events
                 else
                 {
                     audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(folderEndOfSession,
-                    Position.folderStub + position), 0, null));
+                    Position.folderStub + position), 0, null), 10);
                 }
             }
         }

--- a/CrewChiefV4/Events/Strategy.cs
+++ b/CrewChiefV4/Events/Strategy.cs
@@ -212,7 +212,7 @@ namespace CrewChiefV4.Events
                         audioPlayer.playMessage(new QueuedMessage("pit_stop_cost_estimate",
                             MessageContents(folderPitStopCostsUsAbout,
                             TimeSpanWrapper.FromSeconds(playerTimeLostForStop, Precision.SECONDS)),
-                            0, this));
+                            0, this), 10);
                     }
                     waitingForValidDataForBenchmark = false;
                 }
@@ -276,7 +276,7 @@ namespace CrewChiefV4.Events
                                 audioPlayer.playMessage(new QueuedMessage("pit_stop_cost_estimate",
                                     MessageContents(folderPitStopCostsUsAbout,
                                     TimeSpanWrapper.FromSeconds(playerTimeLostForStop, Precision.SECONDS)),
-                                    0, this));
+                                    0, this), 10);
                             }
                             else
                             {
@@ -314,7 +314,7 @@ namespace CrewChiefV4.Events
                                     // this guy has just entered the pit and we predict he'll exit just in front of us
                                     Console.WriteLine("Opponent " + entry.Value.DriverRawName + " will exit the pit close in front of us");
                                     audioPlayer.playMessage(new QueuedMessage("opponent_exiting_in_front", MessageContents(entry.Value,
-                                        folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustInFront), 0, this));
+                                        folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustInFront), 0, this), 10);
 
                                     // only allow one of these every 10 seconds. When an opponent crosses the start line he's 
                                     // removed from this set anyway
@@ -326,7 +326,7 @@ namespace CrewChiefV4.Events
                                     // this guy has just entered the pit and we predict he'll exit just behind us
                                     Console.WriteLine("Opponent " + entry.Value.DriverRawName + " will exit the pit close behind us");
                                     audioPlayer.playMessage(new QueuedMessage("opponent_exiting_behind", MessageContents(entry.Value,
-                                        folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustBehind), 0, this));
+                                        folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustBehind), 0, this), 10);
                                     // only allow one of these every 10 seconds. When an opponent crosses the start line he's 
                                     // removed from this set anyway
                                     nextOpponentPitExitWarningDue = currentGameState.Now.AddSeconds(10);
@@ -1087,7 +1087,7 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessage(new QueuedMessage("pit_stop_position_prediction", fragments, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage("pit_stop_position_prediction", fragments, 0, this), 10);
                 }
             }
             else if (pitPositionEstimatesRequested)

--- a/CrewChiefV4/Events/Timings.cs
+++ b/CrewChiefV4/Events/Timings.cs
@@ -242,7 +242,7 @@ namespace CrewChiefV4.Events
                 currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark != null)
             {
                 // mid-point it true for only 1 tick so this should be safe
-                audioPlayer.playMessage(new QueuedMessage("corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark, 0, this));
+                audioPlayer.playMessage(new QueuedMessage("corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark, 0, this), 10);
             }
             if (GameStateData.onManualFormationLap)
             {
@@ -339,7 +339,7 @@ namespace CrewChiefV4.Events
                                     sectorsUntilNextCloseCarAheadReport = adjustForMidLapPreference(currentGameState.SessionData.SectorNumber,
                                         Utilities.random.Next(closeAheadMinSectorWait, closeAheadMaxSectorWait));
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderBeingHeldUp, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                audioPlayer.playMessage(new QueuedMessage(folderBeingHeldUp, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 10);
                                 OpponentData opponent = currentGameState.getOpponentAtClassPosition(currentGameState.SessionData.ClassPosition - 1, currentGameState.carClass);
                                 if (opponent != null)
                                 {
@@ -353,7 +353,7 @@ namespace CrewChiefV4.Events
                                         {
                                             // either we're faster on entry or faster through
                                             String attackFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsSlowerThroughCorner : folderHeIsSlowerEnteringCorner;
-                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
                                             trackLandmarkAttackDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                         }
                                     }
@@ -390,7 +390,7 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
                                     }
                                 }
                                 else if (gapInFrontStatus == GapStatus.DECREASING)
@@ -405,7 +405,7 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
 
                                         DateTime lastTimeDriverNameUsed = DateTime.MinValue;
                                         if (!trackLandmarkAttackDriverNamesUsed.TryGetValue(opponent.DriverRawName, out lastTimeDriverNameUsed) ||
@@ -417,7 +417,7 @@ namespace CrewChiefV4.Events
                                             {
                                                 // either we're faster on entry or faster through
                                                 String attackFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsSlowerThroughCorner : folderHeIsSlowerEnteringCorner;
-                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this));
+                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
                                                 trackLandmarkAttackDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                             }
                                         }
@@ -435,7 +435,7 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
                                     }
                                 }
                             }
@@ -459,7 +459,7 @@ namespace CrewChiefV4.Events
                                     sectorsUntilNextCloseCarBehindReport = adjustForMidLapPreference(currentGameState.SessionData.SectorNumber,
                                         Utilities.random.Next(closeBehindMinSectorWait, closeBehindMaxSectorWait));
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderBeingPressured, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                audioPlayer.playMessage(new QueuedMessage(folderBeingPressured, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 10);
                                 OpponentData opponent = currentGameState.getOpponentAtClassPosition(currentGameState.SessionData.ClassPosition + 1, currentGameState.carClass);
                                 if (opponent != null)
                                 {
@@ -473,7 +473,7 @@ namespace CrewChiefV4.Events
                                         {
                                             // either we're slower on entry or slower through
                                             String defendFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsFasterThroughCorner : folderHeIsFasterEnteringCorner;
-                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this));
+                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
                                             trackLandmarkDefendDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                         }
                                     }
@@ -510,7 +510,7 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
                                     }
                                 }
                                 else if (gapBehindStatus == GapStatus.DECREASING)
@@ -525,7 +525,7 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 10);
 
                                         DateTime lastTimeDriverNameUsed = DateTime.MinValue;
                                         if (!trackLandmarkDefendDriverNamesUsed.TryGetValue(opponent.DriverRawName, out lastTimeDriverNameUsed) ||
@@ -537,7 +537,7 @@ namespace CrewChiefV4.Events
                                             {
                                                 // either we're slower on entry or slower through
                                                 String defendFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsFasterThroughCorner : folderHeIsFasterEnteringCorner;
-                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this));
+                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
                                                 trackLandmarkDefendDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                             }
                                         }
@@ -555,7 +555,7 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }));
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
                                     }
                                 }
                             }
@@ -581,7 +581,7 @@ namespace CrewChiefV4.Events
 
                                 QueuedMessage message = new QueuedMessage("Timings/gap_ahead", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } });
                                 message.playEvenWhenSilenced = true;
-                                audioPlayer.playMessage(message);
+                                audioPlayer.playMessage(message, 10);
                             }
                         }
                     }
@@ -604,7 +604,7 @@ namespace CrewChiefV4.Events
 
                                 QueuedMessage message = new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } });
                                 message.playEvenWhenSilenced = true;
-                                audioPlayer.playMessage(message);
+                                audioPlayer.playMessage(message, 10);
                             }
                         }
                     }

--- a/CrewChiefV4/Events/TyreMonitor.cs
+++ b/CrewChiefV4/Events/TyreMonitor.cs
@@ -584,19 +584,19 @@ namespace CrewChiefV4.Events
                                 {
                                     case WheelsLockedEnum.FRONTS:
                                         audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingFrontsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this));
+                                            MessageContents(folderLockingFrontsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
                                         break;
                                     case WheelsLockedEnum.LEFT_FRONT:
                                         audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingLeftFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this));
+                                            MessageContents(folderLockingLeftFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
                                         break;
                                     case WheelsLockedEnum.RIGHT_FRONT:
                                         audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingRightFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this));
+                                            MessageContents(folderLockingRightFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
                                         break;
                                     case WheelsLockedEnum.REARS:
                                         audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingRearsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this));
+                                            MessageContents(folderLockingRearsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
                                         break;
                                     default:
                                         break;
@@ -634,42 +634,42 @@ namespace CrewChiefV4.Events
                             {
                                 Console.WriteLine("Spinning fronts out of " + currentCornerName);
                                 audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningFrontsForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this));
+                                    MessageContents(folderSpinningFrontsForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (leftRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold && rightRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning rears out of " + currentCornerName);
                                 audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningRearsForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this));
+                                    MessageContents(folderSpinningRearsForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (leftFrontCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning left front out of " + currentCornerName);
                                 audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningLeftFrontForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this));
+                                    MessageContents(folderSpinningLeftFrontForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (rightFrontCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning right front out of " + currentCornerName);
                                 audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningRightFrontForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this));
+                                    MessageContents(folderSpinningRightFrontForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (leftRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning left rear out of " + currentCornerName);
                                 audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningLeftRearForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this));
+                                    MessageContents(folderSpinningLeftRearForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (rightRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning right rear out of " + currentCornerName);
                                 audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningRightRearForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this));
+                                    MessageContents(folderSpinningRightRearForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                         }
@@ -876,7 +876,7 @@ namespace CrewChiefV4.Events
                 else if (lastTyreTempMessage == null || !messagesHaveSameContent(lastTyreTempMessage, messageContents))
                 {
                     Console.WriteLine("Tyre temp warning, temps : "+ String.Join(", ", messageContents));
-                    audioPlayer.playMessage(new QueuedMessage("tyre_temps", messageContents, Utilities.random.Next(0, 10), this));
+                    audioPlayer.playMessage(new QueuedMessage("tyre_temps", messageContents, Utilities.random.Next(0, 10), this), 5);
                 }
             }
             lastTyreTempMessage = messageContents;
@@ -929,7 +929,7 @@ namespace CrewChiefV4.Events
                 }
                 else if (lastBrakeTempMessage == null || !messagesHaveSameContent(lastBrakeTempMessage, messageContents))
                 {
-                    audioPlayer.playMessage(new QueuedMessage("brake_temps", messageContents, Utilities.random.Next(0, 10), this));
+                    audioPlayer.playMessage(new QueuedMessage("brake_temps", messageContents, Utilities.random.Next(0, 10), this), 5);
                 }
             }
             lastBrakeTempMessage = messageContents;
@@ -966,7 +966,7 @@ namespace CrewChiefV4.Events
             else if (playEvenIfUnchanged || 
                 (lastTyreConditionMessage != null && !messagesHaveSameContent(lastTyreConditionMessage, messageContents) && !wearIsGood))
             {
-                audioPlayer.playMessage(new QueuedMessage("tyre_condition", messageContents, Utilities.random.Next(0, 10), this));
+                audioPlayer.playMessage(new QueuedMessage("tyre_condition", messageContents, Utilities.random.Next(0, 10), this), 5);
             }
             lastTyreConditionMessage = messageContents;
         }
@@ -988,7 +988,7 @@ namespace CrewChiefV4.Events
             else if (minutesRemainingOnTheseTyres > 1 && minutesRemainingOnTheseTyres <= 4 + (timeInSession - timeElapsed) / 60)
             {
                  audioPlayer.playMessage(new QueuedMessage("minutes_on_current_tyres", MessageContents(folderMinutesOnCurrentTyresIntro, 
-                     minutesRemainingOnTheseTyres, folderMinutesOnCurrentTyresOutro), 0, this));                
+                     minutesRemainingOnTheseTyres, folderMinutesOnCurrentTyresOutro), 0, this), 5);                
             }
         }
 
@@ -1009,7 +1009,7 @@ namespace CrewChiefV4.Events
             else if (lapsRemainingOnTheseTyres > 1 && lapsRemainingOnTheseTyres <= 2 + lapsInSession - completedLaps)
             {
                 audioPlayer.playMessage(new QueuedMessage("laps_on_current_tyres", MessageContents(folderLapsOnCurrentTyresIntro, 
-                        lapsRemainingOnTheseTyres, folderLapsOnCurrentTyresOutro), 0, this));              
+                        lapsRemainingOnTheseTyres, folderLapsOnCurrentTyresOutro), 0, this), 5);              
             }
         }
 
@@ -1709,13 +1709,13 @@ namespace CrewChiefV4.Events
                     if (timeRightFrontIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of left front locking, some right front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just left front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftFrontForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftFrontForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1725,13 +1725,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftFrontIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of right front locking, some left front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just right front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightFrontForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightFrontForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1741,13 +1741,13 @@ namespace CrewChiefV4.Events
                     if (timeRightRearIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of left rear locking, some right rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just left rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftRearForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftRearForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1757,13 +1757,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftRearIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of right rear locking, some left rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just right rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightRearForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightRearForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1783,13 +1783,13 @@ namespace CrewChiefV4.Events
                     if (timeRightFrontIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of left front spinning, some right front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just left front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftFrontForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftFrontForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1799,13 +1799,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftFrontIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of right front spinning, some left front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just right front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightFrontForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightFrontForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1815,13 +1815,13 @@ namespace CrewChiefV4.Events
                     if (timeRightRearIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of left rear spinning, some right rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just left rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftRearForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftRearForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }
@@ -1831,13 +1831,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftRearIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of right rear spinning, some left rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                     else
                     {
                         // just right rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightRearForLapWarning, messageDelay, this));
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightRearForLapWarning, messageDelay, this), 0);
                         playedMessage = true;
                     }
                 }

--- a/CrewChiefV4/Properties/AssemblyInfo.cs
+++ b/CrewChiefV4/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("4.9.4.0")]
+[assembly: AssemblyVersion("4.9.4.1")]
 
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CrewChiefV4/Properties/Settings.Designer.cs
+++ b/CrewChiefV4/Properties/Settings.Designer.cs
@@ -3358,5 +3358,17 @@ namespace CrewChiefV4.Properties {
                 this["iracing_enable_auto_fuel_to_end_of_race"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool priortise_messages_depending_on_situation {
+            get {
+                return ((bool)(this["priortise_messages_depending_on_situation"]));
+            }
+            set {
+                this["priortise_messages_depending_on_situation"] = value;
+            }
+        }
     }
 }

--- a/CrewChiefV4/Properties/Settings.settings
+++ b/CrewChiefV4/Properties/Settings.settings
@@ -836,5 +836,8 @@
     <Setting Name="iracing_enable_auto_fuel_to_end_of_race" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="priortise_messages_depending_on_situation" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/CrewChiefV4/QueuedMessage.cs
+++ b/CrewChiefV4/QueuedMessage.cs
@@ -167,13 +167,6 @@ namespace CrewChiefV4
         }
 
         public QueuedMessage(String messageName, List<MessageFragment> messageFragments, int secondsDelay, AbstractEvent abstractEvent,
-            Dictionary<String, Object> validationData, SoundMetadata metadata)
-            : this(messageName, messageFragments, secondsDelay, abstractEvent, validationData)
-        {
-            this.metadata = metadata;
-        }
-
-        public QueuedMessage(String messageName, List<MessageFragment> messageFragments, int secondsDelay, AbstractEvent abstractEvent,
             Dictionary<String, Object> validationData)
             : this(messageName, messageFragments, secondsDelay, abstractEvent)
         {

--- a/CrewChiefV4/ui_text.txt
+++ b/CrewChiefV4/ui_text.txt
@@ -1095,3 +1095,7 @@ iracing_enable_auto_fuel_to_end_of_race = Enable iRacing auto refueling when ent
 iracing_enable_auto_fuel_to_end_of_race_help = Enables auto refueling in iRacing based on fuel calculations done by the app.
 iracing_enable_auto_fuel_to_end_of_race_category = PIT_STOPS_AND_MULTICLASS
 iracing_enable_auto_fuel_to_end_of_race_filter = IRACING
+
+priortise_messages_depending_on_situation = Advanced message prioritisation
+priortise_messages_depending_on_situation_help = Write me
+priortise_messages_depending_on_situation_category = AUDIO_VOICE_AND_CONTROLLERS

--- a/CrewChiefV4/ui_text.txt
+++ b/CrewChiefV4/ui_text.txt
@@ -1097,5 +1097,5 @@ iracing_enable_auto_fuel_to_end_of_race_category = PIT_STOPS_AND_MULTICLASS
 iracing_enable_auto_fuel_to_end_of_race_filter = IRACING
 
 priortise_messages_depending_on_situation = Advanced message prioritisation
-priortise_messages_depending_on_situation_help = Write me
+priortise_messages_depending_on_situation_help = Disable less import messages when under pressure, on a qualy lap, etc
 priortise_messages_depending_on_situation_category = AUDIO_VOICE_AND_CONTROLLERS

--- a/CrewChiefV4/ui_text.txt
+++ b/CrewChiefV4/ui_text.txt
@@ -1097,5 +1097,5 @@ iracing_enable_auto_fuel_to_end_of_race_category = PIT_STOPS_AND_MULTICLASS
 iracing_enable_auto_fuel_to_end_of_race_filter = IRACING
 
 priortise_messages_depending_on_situation = Advanced message prioritisation
-priortise_messages_depending_on_situation_help = Disable less import messages when under pressure, on a qualy lap, etc
+priortise_messages_depending_on_situation_help = Disable less important messages when under pressure, on a qualifying lap, etc
 priortise_messages_depending_on_situation_category = AUDIO_VOICE_AND_CONTROLLERS

--- a/CrewChiefV4_no_sound_files/CrewChiefV4_setup_project.isl
+++ b/CrewChiefV4_no_sound_files/CrewChiefV4_setup_project.isl
@@ -4480,9 +4480,9 @@ RABWAEQALQA1AAEARQB4AHAAcgBlAHMAcwA=
 		<row><td>PROGMSG_IIS_ROLLBACKVROOTS</td><td>##IDS_PROGMSG_IIS_ROLLBACKVROOTS##</td><td/></row>
 		<row><td>PROGMSG_IIS_ROLLBACKWEBSERVICEEXTENSIONS</td><td>##IDS_PROGMSG_IIS_ROLLBACKWEBSERVICEEXTENSIONS##</td><td/></row>
 		<row><td>PROGRAMFILETOLAUNCHATEND</td><td>[INSTALLDIR]CrewChiefV4.Primary output</td><td/></row>
-		<row><td>ProductCode</td><td>{609F385D-1308-4568-8F87-4BF82D61A132}</td><td/></row>
+		<row><td>ProductCode</td><td>{BB4A5836-B8EA-4DE5-A7E6-8C4F008FB076}</td><td/></row>
 		<row><td>ProductName</td><td>CrewChiefV4</td><td/></row>
-		<row><td>ProductVersion</td><td>4.9.4.0</td><td/></row>
+		<row><td>ProductVersion</td><td>4.9.4.1</td><td/></row>
 		<row><td>ProgressType0</td><td>install</td><td/></row>
 		<row><td>ProgressType1</td><td>Installing</td><td/></row>
 		<row><td>ProgressType2</td><td>installed</td><td/></row>


### PR DESCRIPTION
WIP: first cut of automatic rejection of some regular messages. There's not much left to do here - fix the enable / disable property name & help, and some tidying up. 

This is based on the current session conditions (very simple checks for opponents being close, on qually lap, or near race start or end). Each regular message 'play' call includes a 0 - 10 priority. This determines the queue position *and* whether the moderator will reject the message (tell the audio player not to queue it) if it's considered too unimportant for the current session conditions.

The use of priority for queue ordering and as a means to trigger queue rejection is a bit suspect and needs careful consideration (is it safe to do this? I've added a priority to all the messages now, which will affect the queue ordering - will this make stuff sound wrong?)

This PR also include a tweak to the error handling to disable an Event if it fails > 10 times in a session