### PR TITLE
Block messages during spotter pauses

### DIFF
--- a/CrewChiefV4/Audio/AudioPlayer.cs
+++ b/CrewChiefV4/Audio/AudioPlayer.cs
@@ -1223,9 +1223,6 @@ namespace CrewChiefV4.Audio
                             startHangingChannelCloseThread();
                         }
 
-                        // here we assume the message is a voice command response, which is the most common use case 
-                        // for non-spotter immediate messages
-                        populateSoundMetadata(queuedMessage, SoundType.VOICE_COMMAND_RESPONSE, 5);
                         // sanity check...
                         if (queuedMessage.metadata.type == SoundType.REGULAR_MESSAGE)
                         {
@@ -1266,7 +1263,6 @@ namespace CrewChiefV4.Audio
                             startHangingChannelCloseThread();
                         }
                         // default spotter priority is 10
-                        populateSoundMetadata(queuedMessage, SoundType.SPOTTER, 10);
                         immediateClips.Insert(getInsertionIndex(immediateClips, queuedMessage), queuedMessage.messageName, queuedMessage);
 
                         // wake up the monitor thread immediately
@@ -1431,7 +1427,7 @@ namespace CrewChiefV4.Audio
             if (lastMessagePlayed != null)
             {
                 // clear the validation, expiry and other data
-                lastMessagePlayed.prepareToBeRepeated(getMessageId());
+                lastMessagePlayed.prepareToBeRepeated();
                 playMessageImmediately(lastMessagePlayed);
             }
         }
@@ -1485,17 +1481,6 @@ namespace CrewChiefV4.Audio
 
             return !string.IsNullOrWhiteSpace(rawName) && CrewChief.enableDriverNames &&
                 ((SoundCache.hasSuitableTTSVoice && ttsOption != TTS_OPTION.NEVER) || SoundCache.availableDriverNames.Contains(DriverNameHelper.getUsableDriverName(rawName)));
-        }
-
-        // defaultSoundType is only used if we've not already added metadata
-        // defaultPriority is only used if we've not already added metadata
-        private void populateSoundMetadata(QueuedMessage queuedMessage, SoundType defaultSoundType, int defaultPriority)
-        {
-            if (queuedMessage.metadata == null)
-            {
-                queuedMessage.metadata = new SoundMetadata(defaultSoundType, defaultPriority);
-            }
-            queuedMessage.metadata.messageId = getMessageId();
         }
     }
 }

--- a/CrewChiefV4/Audio/SoundMetadata.cs
+++ b/CrewChiefV4/Audio/SoundMetadata.cs
@@ -15,6 +15,7 @@ namespace CrewChiefV4.Audio
         VOICE_COMMAND_RESPONSE, 
         IMPORTANT_MESSAGE,
         REGULAR_MESSAGE,
+        AUTO,        // allow the context (spotter, immediate, regular) to determine the type
         OTHER           // used only for beeps (do we need this?)
     }
 

--- a/CrewChiefV4/CrewChief.cs
+++ b/CrewChiefV4/CrewChief.cs
@@ -570,8 +570,8 @@ namespace CrewChiefV4
             }
             if (AudioPlayer.soundPackLanguage == "it")
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage("current_time",
-                    AbstractEvent.MessageContents(hour, NumberReaderIt2.folderAnd, now.Minute), 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage("current_time", 0,
+                    messageFragments: AbstractEvent.MessageContents(hour, NumberReaderIt2.folderAnd, now.Minute)));
             }
             else
             {
@@ -588,19 +588,19 @@ namespace CrewChiefV4
                 {
                     if (minute == 0)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("current_time",
-                           AbstractEvent.MessageContents(hour, isPastMidDay ? AlarmClock.folderPM : AlarmClock.folderAM), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("current_time", 0,
+                           messageFragments: AbstractEvent.MessageContents(hour, isPastMidDay ? AlarmClock.folderPM : AlarmClock.folderAM)));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("current_time",
-                            AbstractEvent.MessageContents(hour, NumberReader.folderOh, now.Minute, isPastMidDay ? AlarmClock.folderPM : AlarmClock.folderAM), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("current_time", 0,
+                            messageFragments: AbstractEvent.MessageContents(hour, NumberReader.folderOh, now.Minute, isPastMidDay ? AlarmClock.folderPM : AlarmClock.folderAM)));
                     }
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("current_time",
-                        AbstractEvent.MessageContents(hour, now.Minute, isPastMidDay ? AlarmClock.folderPM : AlarmClock.folderAM), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("current_time", 0,
+                        messageFragments: AbstractEvent.MessageContents(hour, now.Minute, isPastMidDay ? AlarmClock.folderPM : AlarmClock.folderAM)));
                 }
             }
         }

--- a/CrewChiefV4/Events/AbstractEvent.cs
+++ b/CrewChiefV4/Events/AbstractEvent.cs
@@ -189,7 +189,7 @@ namespace CrewChiefV4.Events
         {
             if (requestedExplicitly)
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage("no_more_information", MessageContents(AudioPlayer.folderNoMoreData), 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoMoreData, 0));
             }
             // otherwise do nothing
         }

--- a/CrewChiefV4/Events/AlarmClock.cs
+++ b/CrewChiefV4/Events/AlarmClock.cs
@@ -176,22 +176,23 @@ namespace CrewChiefV4.Events
                     }
                     if (minutes < 10)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("alarm",
-                            MessageContents(notifyYouAt, hour, NumberReader.folderOh, minutes, isPastMidDay ? folderPM : folderAM), 0, null)
-                            { metadata = new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage("alarm", 0,
+                            messageFragments: MessageContents(notifyYouAt, hour, NumberReader.folderOh, minutes, isPastMidDay ? folderPM : folderAM),
+                            metadata: new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0)));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("alarm",
-                            MessageContents(notifyYouAt, hour, minutes, isPastMidDay ? folderPM : folderAM), 0, null)
-                            { metadata = new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage("alarm", 0,
+                            messageFragments: MessageContents(notifyYouAt, hour, minutes, isPastMidDay ? folderPM : folderAM),
+                            metadata: new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0)));
                     }
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.CLEAR_ALARM_CLOCK))
             {
                 alarmTimes.Clear();
-                audioPlayer.playMessageImmediately(new QueuedMessage("alarm", MessageContents(AudioPlayer.folderAcknowlegeOK), 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage("alarm", 0,
+                    messageFragments: MessageContents(AudioPlayer.folderAcknowlegeOK)));
             }
 
         }

--- a/CrewChiefV4/Events/AlarmClock.cs
+++ b/CrewChiefV4/Events/AlarmClock.cs
@@ -178,13 +178,13 @@ namespace CrewChiefV4.Events
                     {
                         audioPlayer.playMessageImmediately(new QueuedMessage("alarm", 0,
                             messageFragments: MessageContents(notifyYouAt, hour, NumberReader.folderOh, minutes, isPastMidDay ? folderPM : folderAM),
-                            metadata: new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0)));
+                            type: SoundType.CRITICAL_MESSAGE, priority: 0));
                     }
                     else
                     {
                         audioPlayer.playMessageImmediately(new QueuedMessage("alarm", 0,
                             messageFragments: MessageContents(notifyYouAt, hour, minutes, isPastMidDay ? folderPM : folderAM),
-                            metadata: new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0)));
+                            type: SoundType.CRITICAL_MESSAGE, priority: 0));
                     }
                 }
             }

--- a/CrewChiefV4/Events/Battery.cs
+++ b/CrewChiefV4/Events/Battery.cs
@@ -377,7 +377,7 @@ namespace CrewChiefV4.Events
                         && !this.playedBatteryLowWarning)
                     {
                         this.playedBatteryLowWarning = true;
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, this), 6);
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", 20, messageFragments: MessageContents(Battery.folderLowBattery), abstractEvent: this, priority: 6));
                     }
                     else if (((this.averageUsagePerLap > 0.0f  // If avg usage per lap available, calculate threshold dynamically.
                             && this.windowedAverageChargeLeft < (this.averageUsagePerLap * Battery.BatteryCriticaLapsFactor))
@@ -385,7 +385,7 @@ namespace CrewChiefV4.Events
                         && !this.playedBatteryCriticalWarning)
                     {
                         this.playedBatteryCriticalWarning = true;
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderCriticalBattery), 0, this), 10);
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/level", 0, messageFragments: MessageContents(Battery.folderCriticalBattery), abstractEvent: this, priority: 10));
                     }
                 }
 
@@ -436,44 +436,44 @@ namespace CrewChiefV4.Events
                             {
                                 if (currentGameState.PitData.IsElectricVehicleSwapAllowed)
                                 {
-                                    this.audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 3);
-                                    this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderWeEstimate, estBattLapsLeft, Battery.folderLapsRemaining), 0, this), 3);
+                                    this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", 0,
+                                        MessageContents(RaceTime.folderHalfWayHome, Battery.folderWeEstimate, estBattLapsLeft, Battery.folderLapsRemaining), abstractEvent: this, priority: 3));
                                 }
                                 else
-                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, this), 8);
+                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, abstractEvent: this, priority: 8));
                             }
                             else
-                                this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, this), 3);
+                                this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, abstractEvent: this, priority: 3));
                         }
                         else if (currentGameState.SessionData.SessionLapsRemaining > 3 && estBattLapsLeft == 4 && !this.playedFourLapsRemaining)
                         {
                             this.playedFourLapsRemaining = true;
                             Console.WriteLine("4 laps of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFourLapsEstimate, 0, this), 5);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFourLapsEstimate, 0, abstractEvent: this, priority: 5));
                         }
                         else if (currentGameState.SessionData.SessionLapsRemaining > 2 && estBattLapsLeft == 3 && !this.playedThreeLapsRemaining)
                         {
                             this.playedThreeLapsRemaining = true;
                             Console.WriteLine("3 laps of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderThreeLapsEstimate, 0, this), 7);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderThreeLapsEstimate, 0, abstractEvent: this, priority: 7));
                         }
                         else if (currentGameState.SessionData.SessionLapsRemaining > 1 && estBattLapsLeft == 2 && !this.playedTwoLapsRemaining)
                         {
                             this.playedTwoLapsRemaining = true;
                             Console.WriteLine("2 laps of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoLapsEstimate, 0, this), 10);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoLapsEstimate, 0, abstractEvent: this, priority: 10));
                         }
                         else if (currentGameState.SessionData.SessionLapsRemaining > 0 && estBattLapsLeft == 1)
                         {
                             Console.WriteLine("1 lap of battery charge left, " + battStatusMsg);
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderOneLapEstimate, 0, this), 10);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderOneLapEstimate, 0, abstractEvent: this, priority: 10));
 
                             // If we've not played the pit-now message, play it with a bit of a delay - should probably wait for sector3 here
                             // but i'd have to move some stuff around and I'm an idle fucker
                             if (!this.playedPitForBatteryNow && currentGameState.SessionData.SessionLapsRemaining > 1)
                             {
                                 this.playedPitForBatteryNow = true;
-                                this.audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 10, this), 10);
+                                this.audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 0, secondsDelay: 10, abstractEvent: this, priority: 10));
                             }
                         }
                     }
@@ -508,15 +508,14 @@ namespace CrewChiefV4.Events
                                     if (currentGameState.PitData.IsElectricVehicleSwapAllowed)
                                     {
                                         var minutesLeft = (int)Math.Floor(prevLapStats.AverageBatteryPercentageLeft / this.averageUsagePerMinute);
-                                        this.audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 3);
-                                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(
-                                            Battery.folderWeEstimate, minutesLeft, Battery.folderMinutesRemaining), 0, this), 3);
+                                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", 0, messageFragments: MessageContents(
+                                            RaceTime.folderHalfWayHome, Battery.folderWeEstimate, minutesLeft, Battery.folderMinutesRemaining), abstractEvent: this, priority: 3));
                                     }
                                     else
-                                        this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, this), 8);
+                                        this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceLowBattery, 0, abstractEvent: this, priority: 8));
                                 }
                                 else
-                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, this), 3);
+                                    this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfDistanceGoodBattery, 0, abstractEvent: this, priority: 3));
                             }
                         }
 
@@ -537,12 +536,13 @@ namespace CrewChiefV4.Events
                             }
                             if (currentGameState.SessionData.SessionTimeRemaining > cutoffForVehicleSwapCall)
                             {
-                                this.audioPlayer.playMessage(new QueuedMessage("pit_for_vehicle_swap_now",
-                                    MessageContents(Battery.folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), 0, this), 10);
+                                this.audioPlayer.playMessage(new QueuedMessage("pit_for_vehicle_swap_now",0, 
+                                    messageFragments: MessageContents(Battery.folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), abstractEvent: this, priority: 10));
                             }
                             else
                             {
-                                this.audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_battery", MessageContents(Battery.folderAboutToRunOut), 0, this), 10);
+                                this.audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_battery", 0,
+                                    messageFragments: MessageContents(Battery.folderAboutToRunOut), abstractEvent: this, priority: 10));
                             }
                         }
                         if (estBattMinsLeft <= 2.0f && estBattMinsLeft > 1.8f && !this.playedTwoMinutesRemaining)
@@ -552,7 +552,7 @@ namespace CrewChiefV4.Events
                             this.playedTwoMinutesRemaining = true;
                             this.playedFiveMinutesRemaining = true;
                             this.playedTenMinutesRemaining = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoMinutesBattery, 0, this), 10);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTwoMinutesBattery, 0, abstractEvent: this, priority: 10));
                         }
                         else if (estBattMinsLeft <= 5.0f && estBattMinsLeft > 4.8f && !this.playedFiveMinutesRemaining)
                         {
@@ -560,14 +560,14 @@ namespace CrewChiefV4.Events
 
                             this.playedFiveMinutesRemaining = true;
                             this.playedTenMinutesRemaining = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFiveMinutesBattery, 0, this), 8);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderFiveMinutesBattery, 0, abstractEvent: this, priority: 8));
                         }
                         else if (estBattMinsLeft <= 10.0f && estBattMinsLeft > 9.8f && !this.playedTenMinutesRemaining)
                         {
                             Console.WriteLine("Less than 10 mins of battery charge left, " + battStatusMsg);
 
                             this.playedTenMinutesRemaining = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTenMinutesBattery, 0, this), 5);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderTenMinutesBattery, 0, abstractEvent: this, priority: 5));
                         }
                         else if (!this.playedHalfBatteryChargeWarning && this.windowedAverageChargeLeft / this.initialBatteryChargePercentage <= 0.55f &&
                             this.windowedAverageChargeLeft / this.initialBatteryChargePercentage >= 0.45f)
@@ -576,7 +576,7 @@ namespace CrewChiefV4.Events
 
                             // warning message for battery left - these play as soon previous lap average charge drops below 1/2.
                             this.playedHalfBatteryChargeWarning = true;
-                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfChargeWarning, 0, this), 3);
+                            this.audioPlayer.playMessage(new QueuedMessage(Battery.folderHalfChargeWarning, 0, abstractEvent: this, priority: 3));
                         }
                     }  // if Timed or fixed lap race
 
@@ -587,16 +587,19 @@ namespace CrewChiefV4.Events
                         && !this.playedBatteryCriticalWarning)
                     {
                         var bu = this.EvaluateBatteryUse();
+                        int delay = Utilities.random.Next(0, 11);
                         if (bu == Battery.BatteryUseTrend.Increasing
                             && this.lastReportedTrend != Battery.BatteryUseTrend.Increasing)
                         {
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseIncreasing), Utilities.random.Next(0, 11), this), 3);
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", delay + 20, secondsDelay: delay,
+                                messageFragments: MessageContents(Battery.folderUseIncreasing), abstractEvent: this, priority: 3));
                             this.lastReportedTrend = Battery.BatteryUseTrend.Increasing;
                         }
                         else if (bu == Battery.BatteryUseTrend.Decreasing
                             && this.lastReportedTrend != Battery.BatteryUseTrend.Decreasing)
                         {
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseDecreasing), Utilities.random.Next(0, 11), this), 3);
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/trend", delay, secondsDelay: delay,
+                                messageFragments: MessageContents(Battery.folderUseDecreasing), abstractEvent: this, priority: 3));
                             this.lastReportedTrend = Battery.BatteryUseTrend.Decreasing;
                         }
                         else if (bu == Battery.BatteryUseTrend.Stable)
@@ -768,9 +771,9 @@ namespace CrewChiefV4.Events
                         messageFragments.Add(MessageFragment.Text(Battery.folderPercentOfYourBattery));
 
                         if (useImmediateQueue)
-                            this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, null));
+                            this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/prev_lap_use", 0, messageFragments: messageFragments));
                         else
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, this), 1);
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", 0, messageFragments: messageFragments, abstractEvent: this, priority: 1));
                     }
                     else
                     {
@@ -780,9 +783,9 @@ namespace CrewChiefV4.Events
                         messageFragments.Add(MessageFragment.Text(Battery.folderPercentOfYourBattery));
 
                         if (useImmediateQueue)
-                            this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, null));
+                            this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/prev_lap_use", 0, messageFragments: messageFragments));
                         else
-                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", messageFragments, 0, this), 1);
+                            this.audioPlayer.playMessage(new QueuedMessage("Battery/prev_lap_use", 0, messageFragments: messageFragments, abstractEvent: this, priority: 1));
 
                     }
                 }
@@ -807,7 +810,7 @@ namespace CrewChiefV4.Events
             {
                 haveData = true;
                 batteryRunningLow = false;
-                this.audioPlayer.playMessageImmediately(new QueuedMessage(Battery.folderPlentyOfBattery, 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage(Battery.folderPlentyOfBattery, 0));
             }
             else if ((this.averageUsagePerLap > 0.0f  // If avg usage per lap available, calculate threshold dynamically.
                     && this.windowedAverageChargeLeft > (this.averageUsagePerLap * Battery.BatteryLowLapsFactor))
@@ -820,9 +823,9 @@ namespace CrewChiefV4.Events
                 messageFragments.Add(MessageFragment.Text(Battery.folderPercentRemaining));
 
                 if (useImmediateQueue)
-                    this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", messageFragments, 0, null));
+                    this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", 0, messageFragments: messageFragments));
                 else
-                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", messageFragments, 0, null), 5);
+                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", 0, messageFragments: messageFragments, priority: 5));
             }
             else if ((this.averageUsagePerLap > 0.0f  // If avg usage per lap available, calculate threshold dynamically.
                     && this.windowedAverageChargeLeft > (this.averageUsagePerLap * Battery.BatteryCriticaLapsFactor))
@@ -830,9 +833,9 @@ namespace CrewChiefV4.Events
             {
                 haveData = true;
                 if (useImmediateQueue)
-                    this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, null));
+                    this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", 0, messageFragments: MessageContents(Battery.folderLowBattery)));
                 else
-                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", MessageContents(Battery.folderLowBattery), 0, this), 5);
+                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", 0, messageFragments: MessageContents(Battery.folderLowBattery), abstractEvent: this, priority: 5));
             }
             else if (this.windowedAverageChargeLeft > 0)
             {
@@ -842,9 +845,9 @@ namespace CrewChiefV4.Events
                 messageFragments.Add(MessageFragment.Text(Battery.folderAboutToRunOut));
                 
                 if (useImmediateQueue)
-                    this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", messageFragments, 0, null));
+                    this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/level", 0, messageFragments: messageFragments));
                 else
-                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", messageFragments, 0, null), 5);
+                    this.audioPlayer.playMessage(new QueuedMessage("Battery/level", 0, messageFragments: messageFragments, abstractEvent: this, priority: 5));
             }
 
             if (batteryRunningLow || !this.batteryUseActive)
@@ -866,9 +869,9 @@ namespace CrewChiefV4.Events
                 }
                 else if (lapsOfBatteryChargeLeft <= 1)
                     if (useImmediateQueue)
-                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null));
+                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", 0, messageFragments: MessageContents(Battery.folderAboutToRunOut)));
                     else
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null), 5);
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", 0, messageFragments: MessageContents(Battery.folderAboutToRunOut), abstractEvent: this, priority: 5));
                 else
                 {
                     var messageFragments = new List<MessageFragment>();
@@ -876,9 +879,9 @@ namespace CrewChiefV4.Events
                     messageFragments.Add(MessageFragment.Integer(lapsOfBatteryChargeLeft, false));
                     messageFragments.Add(MessageFragment.Text(outroSound));
                     if (useImmediateQueue)
-                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", messageFragments, 0, null));
+                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", 0, messageFragments: messageFragments));
                     else
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", messageFragments, 0, null), 5);
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", 0, messageFragments: messageFragments, priority: 5));
                 }
             }
             else if (this.averageUsagePerMinute > 0.0f) // Timed race.
@@ -897,9 +900,9 @@ namespace CrewChiefV4.Events
                 }
                 else if (minutesOfBatteryChargeLeft <= 1)
                     if (useImmediateQueue)
-                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null));
+                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", 0, messageFragments: MessageContents(Battery.folderAboutToRunOut)));
                     else
-                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", MessageContents(Battery.folderAboutToRunOut), 0, null), 10);
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", 0, messageFragments: MessageContents(Battery.folderAboutToRunOut), abstractEvent: this, priority: 10));
                 else
                 {
                     var messageFragments = new List<MessageFragment>();
@@ -907,9 +910,9 @@ namespace CrewChiefV4.Events
                     messageFragments.Add(MessageFragment.Integer(minutesOfBatteryChargeLeft, false));
                     messageFragments.Add(MessageFragment.Text(outroSound));
                     if (useImmediateQueue)
-                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", messageFragments, 0, null));
+                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", 0, messageFragments: messageFragments));
                     else
-                        this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/estimate", messageFragments, 0, null));
+                        this.audioPlayer.playMessage(new QueuedMessage("Battery/estimate", 0, messageFragments: messageFragments, abstractEvent: this, priority: 10));
                 }
             }
 
@@ -948,11 +951,11 @@ namespace CrewChiefV4.Events
             // Report usage trend:
             var bu = this.EvaluateBatteryUse();
             if (bu == BatteryUseTrend.Decreasing)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseDecreasing), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/trend", 0, messageFragments: MessageContents(Battery.folderUseDecreasing)));
             else if (bu == BatteryUseTrend.Increasing)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseIncreasing), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/trend", 0, messageFragments: MessageContents(Battery.folderUseIncreasing)));
             else if (bu == BatteryUseTrend.Stable)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/trend", MessageContents(Battery.folderUseStable), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/trend", 0, messageFragments: MessageContents(Battery.folderUseStable)));
 
             var midRaceReached = false;
             var batteryAdvice = BatteryAdvice.Unknown;
@@ -1044,13 +1047,17 @@ namespace CrewChiefV4.Events
             }
 
             if (batteryAdvice == BatteryAdvice.BatteryUseSpotOn)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", MessageContents(midRaceReached ? Battery.folderShouldMakeEnd : Battery.folderShouldMakeHalfDistance), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", 0, 
+                    messageFragments: MessageContents(midRaceReached ? Battery.folderShouldMakeEnd : Battery.folderShouldMakeHalfDistance)));
             else if (batteryAdvice == BatteryAdvice.IncreaseBatteryUse)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", MessageContents(midRaceReached ? Battery.folderIncreaseUseEasilyMakeEnd : Battery.folderIncreaseUseEasilyMakeHalfDistance), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", 0,
+                    messageFragments: MessageContents(midRaceReached ? Battery.folderIncreaseUseEasilyMakeEnd : Battery.folderIncreaseUseEasilyMakeHalfDistance)));
             else if (batteryAdvice == BatteryAdvice.ReduceBatteryUse)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", MessageContents(midRaceReached ? Battery.folderReduceUseToMakeEnd : Battery.folderReduceUseHalfDistance), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", 0, 
+                    messageFragments: MessageContents(midRaceReached ? Battery.folderReduceUseToMakeEnd : Battery.folderReduceUseHalfDistance)));
             else if (batteryAdvice == BatteryAdvice.WontMakeItWithoutPitting)
-                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", MessageContents(midRaceReached ? Battery.folderWontMakeEndWoPit : Battery.folderWontMakeHalfDistanceWoPit), 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage("Battery/advice", 0,
+                    messageFragments: MessageContents(midRaceReached ? Battery.folderWontMakeEndWoPit : Battery.folderWontMakeHalfDistanceWoPit)));
         }
     }
 }

--- a/CrewChiefV4/Events/ConditionsMonitor.cs
+++ b/CrewChiefV4/Events/ConditionsMonitor.cs
@@ -158,9 +158,9 @@ namespace CrewChiefV4.Events
                             lastAirTempReport = currentGameState.Now;
                             lastTrackTempReport = currentGameState.Now;
                             // do the reporting
-                            audioPlayer.playMessage(new QueuedMessage("airAndTrackTemp", MessageContents
+                            audioPlayer.playMessage(new QueuedMessage("airAndTrackTemp", 10, messageFragments: MessageContents
                                 (folderAirAndTrackTempIncreasing, folderAirTempIsNow, convertTemp(currentConditions.AmbientTemperature),
-                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
+                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), abstractEvent: this, priority: 0));
                             reportedCombinedTemps = true;
                         }
                         else if (trackTempToUse < trackTempAtLastReport - minTrackTempDeltaToReport && currentConditions.AmbientTemperature < airTempAtLastReport - minAirTempDeltaToReport)
@@ -170,9 +170,9 @@ namespace CrewChiefV4.Events
                             lastAirTempReport = currentGameState.Now;
                             lastTrackTempReport = currentGameState.Now;
                             // do the reporting
-                            audioPlayer.playMessage(new QueuedMessage("airAndTrackTemp", MessageContents
+                            audioPlayer.playMessage(new QueuedMessage("airAndTrackTemp", 10, messageFragments: MessageContents
                                 (folderAirAndTrackTempDecreasing, folderAirTempIsNow, convertTemp(currentConditions.AmbientTemperature),
-                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
+                                folderTrackTempIsNow, convertTemp(trackTempToUse), getTempUnit()), abstractEvent: this, priority: 0));
                             reportedCombinedTemps = true;
                         }
                     }
@@ -183,16 +183,16 @@ namespace CrewChiefV4.Events
                             airTempAtLastReport = currentConditions.AmbientTemperature;
                             lastAirTempReport = currentGameState.Now;
                             // do the reporting
-                            audioPlayer.playMessage(new QueuedMessage("airTemp", MessageContents
-                                (folderAirTempIncreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this), 0);
+                            audioPlayer.playMessage(new QueuedMessage("airTemp", 10, messageFragments: MessageContents
+                                (folderAirTempIncreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), abstractEvent: this, priority: 0));
                         }
                         else if (currentConditions.AmbientTemperature < airTempAtLastReport - minAirTempDeltaToReport)
                         {
                             airTempAtLastReport = currentConditions.AmbientTemperature;
                             lastAirTempReport = currentGameState.Now;
                             // do the reporting
-                            audioPlayer.playMessage(new QueuedMessage("airTemp", MessageContents
-                                (folderAirTempDecreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this), 0);
+                            audioPlayer.playMessage(new QueuedMessage("airTemp", 10, messageFragments: MessageContents
+                                (folderAirTempDecreasing, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), abstractEvent: this, priority: 0));
                         }
                     }
                     if (!reportedCombinedTemps && canReportTrackChange)
@@ -202,16 +202,16 @@ namespace CrewChiefV4.Events
                             trackTempAtLastReport = trackTempToUse;
                             lastTrackTempReport = currentGameState.Now;
                             // do the reporting
-                            audioPlayer.playMessage(new QueuedMessage("trackTemp", MessageContents
-                                (folderTrackTempIncreasing, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
+                            audioPlayer.playMessage(new QueuedMessage("trackTemp", 10, messageFragments: MessageContents
+                                (folderTrackTempIncreasing, convertTemp(trackTempToUse), getTempUnit()), abstractEvent: this, priority: 0));
                         }
                         else if (trackTempToUse < trackTempAtLastReport - minTrackTempDeltaToReport)
                         {
                             trackTempAtLastReport = trackTempToUse;
                             lastTrackTempReport = currentGameState.Now;
                             // do the reporting
-                            audioPlayer.playMessage(new QueuedMessage("trackTemp", MessageContents
-                                (folderTrackTempDecreasing, convertTemp(trackTempToUse), getTempUnit()), 0, this), 0);
+                            audioPlayer.playMessage(new QueuedMessage("trackTemp", 10, messageFragments: MessageContents
+                                (folderTrackTempDecreasing, convertTemp(trackTempToUse), getTempUnit()), abstractEvent: this, priority: 0));
                         }
                     }
                     //pcars2 test warning
@@ -246,8 +246,8 @@ namespace CrewChiefV4.Events
 
                                     if (minutes > 2)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("expecting_rain", MessageContents(folderExpectRain,
-                                            new TimeSpanWrapper(TimeSpan.FromMinutes(minutes), Precision.MINUTES)), 0, this), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("expecting_rain", 10, messageFragments: MessageContents(folderExpectRain,
+                                            new TimeSpanWrapper(TimeSpan.FromMinutes(minutes), Precision.MINUTES)), abstractEvent: this));
                                     }
                                 }
                             }
@@ -270,13 +270,13 @@ namespace CrewChiefV4.Events
                             {
                                 rainAtLastReport = currentGameState.RainDensity;
                                 lastRainReport = currentGameState.Now;
-                                audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 0, this), 2);
+                                audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 10, abstractEvent: this, priority: 2));
                             }
                             else if (currentConditions.RainDensity == 1 && rainAtLastReport == 0)
                             {
                                 rainAtLastReport = currentGameState.RainDensity;
                                 lastRainReport = currentGameState.Now;
-                                audioPlayer.playMessage(new QueuedMessage(folderSeeingSomeRain, 0, this), 5);
+                                audioPlayer.playMessage(new QueuedMessage(folderSeeingSomeRain, 10, abstractEvent: this, priority: 5));
                             }
                         }
                         else if (CrewChief.gameDefinition.gameEnum == GameEnum.RF2_64BIT || CrewChief.gameDefinition.gameEnum == GameEnum.PCARS2)
@@ -313,7 +313,7 @@ namespace CrewChiefV4.Events
                                         audioPlayer.playMessageImmediately(new QueuedMessage(folderRainMax, 0, null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
                                         break;
                                     case RainLevel.NONE:
-                                        audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 0, this), 3);
+                                        audioPlayer.playMessage(new QueuedMessage(folderStoppedRaining, 10, abstractEvent: this, priority: 3));
                                         break;
                                 }
                                 lastRainReport = currentGameState.Now;
@@ -375,13 +375,13 @@ namespace CrewChiefV4.Events
             {
                 if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHATS_THE_AIR_TEMP))
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("airTemp",
-                        MessageContents(folderAirTempIsNow, convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("airTemp", 0,
+                        messageFragments: MessageContents(folderAirTempIsNow, convertTemp(currentConditions.AmbientTemperature), getTempUnit())));
                 }
                 if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHATS_THE_TRACK_TEMP))
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("trackTemp",
-                        MessageContents(folderTrackTempIsNow, convertTemp(currentConditions.TrackTemperature), getTempUnit()), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("trackTemp", 0,
+                        messageFragments: MessageContents(folderTrackTempIsNow, convertTemp(currentConditions.TrackTemperature), getTempUnit())));
                 }
             }
         }

--- a/CrewChiefV4/Events/DamageReporting.cs
+++ b/CrewChiefV4/Events/DamageReporting.cs
@@ -347,16 +347,16 @@ namespace CrewChiefV4.Events
                     switch (puncture)
                     {
                         case CornerData.Corners.FRONT_LEFT:
-                            audioPlayer.playMessage(new QueuedMessage(folderLeftFrontPuncture, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderLeftFrontPuncture, 0, abstractEvent: this, priority: 10));
                             break;
                         case CornerData.Corners.FRONT_RIGHT:
-                            audioPlayer.playMessage(new QueuedMessage(folderRightFrontPuncture, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderRightFrontPuncture, 0, abstractEvent: this, priority: 10));
                             break;
                         case CornerData.Corners.REAR_LEFT:
-                            audioPlayer.playMessage(new QueuedMessage(folderLeftRearPuncture, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderLeftRearPuncture, 0, abstractEvent: this, priority: 10));
                             break;
                         case CornerData.Corners.REAR_RIGHT:
-                            audioPlayer.playMessage(new QueuedMessage(folderRightRearPuncture, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderRightRearPuncture, 0, abstractEvent: this, priority: 10));
                             break;
                     }
                 }
@@ -793,7 +793,7 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderBustedEngine, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderBustedEngine, 0, abstractEvent: this, priority: 10));
                         if (allowRants)
                         {
                             audioPlayer.playRant("damage_rant", null);
@@ -802,11 +802,11 @@ namespace CrewChiefV4.Events
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereEngineDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereEngineDamage, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorEngineDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorEngineDamage, 0, abstractEvent: this, priority: 10));
                 }
             }
             else if (damageToReportNext.Item1 == Component.TRANNY)
@@ -815,7 +815,7 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderBustedTransmission, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderBustedTransmission, 0, abstractEvent: this, priority: 10));
                         if (allowRants)
                         {
                             audioPlayer.playRant("damage_rant", null);
@@ -824,11 +824,11 @@ namespace CrewChiefV4.Events
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereTransmissionDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereTransmissionDamage, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorTransmissionDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorTransmissionDamage, 0, abstractEvent: this, priority: 10));
                 }
             }
             else if (damageToReportNext.Item1 == Component.SUSPENSION)
@@ -837,7 +837,7 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderBustedSuspension, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderBustedSuspension, 0, abstractEvent: this, priority: 10));
                         if (allowRants)
                         {
                             audioPlayer.playRant("damage_rant", null);
@@ -848,28 +848,28 @@ namespace CrewChiefV4.Events
                 {
                     if (isMissingWheel)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderMissingWheel, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderMissingWheel, 0, abstractEvent: this, priority: 10));
                     }
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereSuspensionDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereSuspensionDamage, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR && !isMissingWheel)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorSuspensionDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorSuspensionDamage, 0, abstractEvent: this, priority: 10));
                 }
             }
             else if (damageToReportNext.Item1 == Component.BRAKES)
             {
                 if (damageToReportNext.Item2 == DamageLevel.DESTROYED)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderBustedBrakes, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderBustedBrakes, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereBrakeDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereBrakeDamage, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorBrakeDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorBrakeDamage, 0, abstractEvent: this, priority: 10));
                 }
             }
             else if (damageToReportNext.Item1 == Component.AERO)
@@ -878,20 +878,20 @@ namespace CrewChiefV4.Events
                 {
                     if (!checkIfDriverIsOK(now))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, abstractEvent: this, priority: 10));
                     }
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MAJOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderSevereAeroDamage, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.MINOR)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderMinorAeroDamage, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderMinorAeroDamage, 0, abstractEvent: this, priority: 10));
                 }
                 else if (damageToReportNext.Item2 == DamageLevel.TRIVIAL)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(folderJustAScratch, 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage(folderJustAScratch, 0, abstractEvent: this, priority: 3));
                 }
             }
         }
@@ -904,12 +904,12 @@ namespace CrewChiefV4.Events
                 if (speed < 2 && isUpsideDown(orientationSamples.Last.Value))
                 {
                     // we're almost stopped and we're upside down
-                    audioPlayer.playMessage(new QueuedMessage(folderStoppedUpsideDown, 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage(folderStoppedUpsideDown, 0, abstractEvent: this, priority: 3));
                 }
                 else
                 {
                     // we may be rolling, or may have reset and are now racing again:
-                    audioPlayer.playMessage(new QueuedMessage(folderRolled, 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage(folderRolled, 0, abstractEvent: this, priority: 3));
                 }
                 // don't check again for a while:
                 isRolling = false;

--- a/CrewChiefV4/Events/EngineMonitor.cs
+++ b/CrewChiefV4/Events/EngineMonitor.cs
@@ -79,7 +79,7 @@ namespace CrewChiefV4.Events
                     currentGameState.PositionAndMotionData.CarSpeed < 5)
                 {
                     // Play stalled warning straight away
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderStalled, 0, this));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderStalled, 3));
                     // don't re-check stalled warning for a couple of minutes.
                     nextStalledCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     // move the oil and fuel pressure checks out a bit to allow it to settle
@@ -91,13 +91,13 @@ namespace CrewChiefV4.Events
                     // don't check oil or fuel pressure if we're stalled
                     if (currentGameState.EngineData.EngineOilPressureWarning && currentGameState.Now > nextOilPressureCheck)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLowOilPressure, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderLowOilPressure, 7, abstractEvent:this), 10);
                         // don't re-check oil pressure for a couple of minutes
                         nextOilPressureCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     }
                     if (currentGameState.EngineData.EngineFuelPressureWarning && currentGameState.Now > nextFuelPressureCheck)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLowFuelPressure, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderLowFuelPressure, 7, abstractEvent: this), 10);
                         // don't re-check fuel pressure for a couple of minutes
                         nextFuelPressureCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     }
@@ -119,12 +119,12 @@ namespace CrewChiefV4.Events
                         if (currentEngineStatus.HasFlag(EngineStatus.ALL_CLEAR))
                         {
                             lastStatusMessage = currentEngineStatus;
-                            audioPlayer.playMessage(new QueuedMessage(folderAllClear, 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderAllClear, 10, abstractEvent: this), 5);
                         }
                         else if (currentEngineStatus.HasFlag(EngineStatus.HOT_OIL) && currentEngineStatus.HasFlag(EngineStatus.HOT_WATER))
                         {
                             lastStatusMessage = currentEngineStatus;
-                            audioPlayer.playMessage(new QueuedMessage(folderHotOilAndWater, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderHotOilAndWater, 10, abstractEvent: this), 10);
                         }
                         if (currentEngineStatus.HasFlag(EngineStatus.HOT_OIL))
                         {
@@ -132,7 +132,7 @@ namespace CrewChiefV4.Events
                             if (!lastStatusMessage.HasFlag(EngineStatus.HOT_OIL) && !lastStatusMessage.HasFlag(EngineStatus.HOT_WATER))
                             {
                                 lastStatusMessage = currentEngineStatus;
-                                audioPlayer.playMessage(new QueuedMessage(folderHotOil, 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderHotOil, 10, abstractEvent: this), 10);
                             }
                         }
                         if (currentEngineStatus.HasFlag(EngineStatus.HOT_WATER))
@@ -141,7 +141,7 @@ namespace CrewChiefV4.Events
                             if (!lastStatusMessage.HasFlag(EngineStatus.HOT_OIL) && !lastStatusMessage.HasFlag(EngineStatus.HOT_WATER))
                             {
                                 lastStatusMessage = currentEngineStatus;
-                                audioPlayer.playMessage(new QueuedMessage(folderHotWater, 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderHotWater, 10, abstractEvent: this), 10);
                             }
                         }
                     }

--- a/CrewChiefV4/Events/EngineMonitor.cs
+++ b/CrewChiefV4/Events/EngineMonitor.cs
@@ -91,13 +91,13 @@ namespace CrewChiefV4.Events
                     // don't check oil or fuel pressure if we're stalled
                     if (currentGameState.EngineData.EngineOilPressureWarning && currentGameState.Now > nextOilPressureCheck)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLowOilPressure, 7, abstractEvent:this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderLowOilPressure, 7, abstractEvent:this, priority: 10));
                         // don't re-check oil pressure for a couple of minutes
                         nextOilPressureCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     }
                     if (currentGameState.EngineData.EngineFuelPressureWarning && currentGameState.Now > nextFuelPressureCheck)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLowFuelPressure, 7, abstractEvent: this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderLowFuelPressure, 7, abstractEvent: this, priority: 10));
                         // don't re-check fuel pressure for a couple of minutes
                         nextFuelPressureCheck = currentGameState.Now.Add(TimeSpan.FromMinutes(2));
                     }
@@ -119,12 +119,12 @@ namespace CrewChiefV4.Events
                         if (currentEngineStatus.HasFlag(EngineStatus.ALL_CLEAR))
                         {
                             lastStatusMessage = currentEngineStatus;
-                            audioPlayer.playMessage(new QueuedMessage(folderAllClear, 10, abstractEvent: this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderAllClear, 10, abstractEvent: this, priority: 5));
                         }
                         else if (currentEngineStatus.HasFlag(EngineStatus.HOT_OIL) && currentEngineStatus.HasFlag(EngineStatus.HOT_WATER))
                         {
                             lastStatusMessage = currentEngineStatus;
-                            audioPlayer.playMessage(new QueuedMessage(folderHotOilAndWater, 10, abstractEvent: this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderHotOilAndWater, 10, abstractEvent: this, priority: 10));
                         }
                         if (currentEngineStatus.HasFlag(EngineStatus.HOT_OIL))
                         {
@@ -132,7 +132,7 @@ namespace CrewChiefV4.Events
                             if (!lastStatusMessage.HasFlag(EngineStatus.HOT_OIL) && !lastStatusMessage.HasFlag(EngineStatus.HOT_WATER))
                             {
                                 lastStatusMessage = currentEngineStatus;
-                                audioPlayer.playMessage(new QueuedMessage(folderHotOil, 10, abstractEvent: this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderHotOil, 10, abstractEvent: this, priority: 10));
                             }
                         }
                         if (currentEngineStatus.HasFlag(EngineStatus.HOT_WATER))
@@ -141,7 +141,7 @@ namespace CrewChiefV4.Events
                             if (!lastStatusMessage.HasFlag(EngineStatus.HOT_OIL) && !lastStatusMessage.HasFlag(EngineStatus.HOT_WATER))
                             {
                                 lastStatusMessage = currentEngineStatus;
-                                audioPlayer.playMessage(new QueuedMessage(folderHotWater, 10, abstractEvent: this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderHotWater, 10, abstractEvent: this, priority: 10));
                             }
                         }
                     }

--- a/CrewChiefV4/Events/FlagsMonitor.cs
+++ b/CrewChiefV4/Events/FlagsMonitor.cs
@@ -355,7 +355,7 @@ namespace CrewChiefV4.Events
                 if (currentGameState.Now > disableBlackFlagUntil)
                 {
                     disableBlackFlagUntil = currentGameState.Now.Add(timeBetweenBlackFlagMessages);
-                    audioPlayer.playMessage(new QueuedMessage(folderBlackFlag, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderBlackFlag, 0, abstractEvent: this, priority: 10));
                 }
             }
             else if (!currentGameState.PitData.InPitlane && currentGameState.SessionData.Flag == FlagEnum.BLUE)
@@ -375,7 +375,7 @@ namespace CrewChiefV4.Events
                             blueFlagWarningCountForSingleDriver++;
                         }
                         // immediate to prevent it being delayed by the hard-parts logic
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderBlueFlag, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderBlueFlag, 6, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                     }
                 }
             }
@@ -385,7 +385,7 @@ namespace CrewChiefV4.Events
                 if (currentGameState.Now > disableWhiteFlagUntil)
                 {
                     disableWhiteFlagUntil = currentGameState.Now.Add(timeBetweenWhiteFlagMessages);
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderWhiteFlagEU, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderWhiteFlagEU, 2, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                 }
             }
             if (currentGameState.FlagData.numCarsPassedIllegally >= 0
@@ -422,34 +422,35 @@ namespace CrewChiefV4.Events
                         {
                             var usableDriverName = DriverNameHelper.getUsableDriverName(currentGameState.StockCarRulesData.luckyDogNameRaw);
                             Console.WriteLine("Stock Car Rule triggered: Lucky Dog is - " + usableDriverName);
-                            audioPlayer.playMessageImmediately(new QueuedMessage("flags/lucky_dog_is",
-                                MessageContents(folderOpponentIsLuckyDog, usableDriverName), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("flags/lucky_dog_is", 0,
+                                messageFragments: MessageContents(folderOpponentIsLuckyDog, usableDriverName), abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                     }
 
                     // See if rule has changed.
                     if (previousGameState.StockCarRulesData.stockCarRuleApplicable != currentGameState.StockCarRulesData.stockCarRuleApplicable)
                     {
+                        int delay = Utilities.random.Next(3, 7);
                         Console.WriteLine("Stock Car Rule triggered: " + currentGameState.StockCarRulesData.stockCarRuleApplicable);
                         if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.LUCKY_DOG_PASS_ON_LEFT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderWeAreLuckyDog, Utilities.random.Next(3, 7), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderWeAreLuckyDog, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 10));
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.LUCKY_DOG_ALLOW_TO_PASS_ON_LEFT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderAllowLuckyDogPass, Utilities.random.Next(3, 7), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderAllowLuckyDogPass, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 10));
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.LEADER_CHOOSE_LANE)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderLeaderChooseLane, Utilities.random.Next(3, 7), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderLeaderChooseLane, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 10));
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.WAVE_AROUND_PASS_ON_RIGHT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderWeHaveBeenWavedAround, Utilities.random.Next(3, 7), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderWeHaveBeenWavedAround, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 10));
                         }
                         else if (currentGameState.StockCarRulesData.stockCarRuleApplicable == StockCarRule.MOVE_TO_EOLL)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderEOLLPenalty, Utilities.random.Next(3, 7), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderEOLLPenalty, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 10));
                         }
                     }
                 }
@@ -465,7 +466,7 @@ namespace CrewChiefV4.Events
                         if (currentGreenFlagLuckyDogStatus == GreenFlagLuckyDogStatus.WE_ARE_IN_LUCKY_DOG)
                         {
                             Console.WriteLine("Stock Car Rule triggered: " + currentGreenFlagLuckyDogStatus);
-                            audioPlayer.playMessage(new QueuedMessage(folderWeAreInLuckyDogPosition, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderWeAreInLuckyDogPosition, 10, abstractEvent: this, priority: 10));
                         }
                         else if (currentGreenFlagLuckyDogStatus == GreenFlagLuckyDogStatus.PASS_FOR_LUCKY_DOG)
                         {
@@ -473,12 +474,13 @@ namespace CrewChiefV4.Events
                             Console.WriteLine("Stock Car Rule triggered: " + currentGreenFlagLuckyDogStatus + " driver to pass: " + (carAhead != null ? carAhead.DriverRawName : "not found"));
                             if (carAhead != null && AudioPlayer.canReadName(carAhead.DriverRawName))
                             {
-                                audioPlayer.playMessage(new QueuedMessage("push_to_pass_lucky_dog",
-                                    MessageContents(folderPassDriverForLuckyDogPositionIntro, carAhead, folderPassDriverForLuckyDogPositionOutro), 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage("push_to_pass_lucky_dog", 6,
+                                    messageFragments: MessageContents(folderPassDriverForLuckyDogPositionIntro, carAhead, folderPassDriverForLuckyDogPositionOutro),
+                                    abstractEvent: this, priority: 10));
                             }
                             else
                             {
-                                audioPlayer.playMessage(new QueuedMessage(folderPassCarAheadForLuckyPositionDog, 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderPassCarAheadForLuckyPositionDog, 6, abstractEvent: this, priority: 10));
                             }
                         }
                         greenFlagLuckyDogMessageCountInSession++;
@@ -574,15 +576,15 @@ namespace CrewChiefV4.Events
                         if (currentGameState.FlagData.numCarsPassedIllegally == 1)
                         {
                             // don't allow any other message to override this one:
-                            audioPlayer.playMessageImmediately(new QueuedMessage("give_position_back_repeat", MessageContents(folderGiveOnePositionsBackNextWarning), 0,
-                                null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("give_position_back_repeat", 3,
+                                messageFragments: MessageContents(folderGiveOnePositionsBackNextWarning), type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                         }
                         else
                         {
                             // don't allow any other message to override this one:
-                            audioPlayer.playMessageImmediately(new QueuedMessage("give_positions_back_repeat", MessageContents(folderGivePositionsBackNextWarningIntro,
-                                currentGameState.FlagData.numCarsPassedIllegally, folderGivePositionsBackNextWarningOutro), 0,
-                                null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("give_positions_back_repeat", 3,
+                                messageFragments: MessageContents(folderGivePositionsBackNextWarningIntro, currentGameState.FlagData.numCarsPassedIllegally, folderGivePositionsBackNextWarningOutro),
+                                type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                         }
                     }
                     else
@@ -591,15 +593,15 @@ namespace CrewChiefV4.Events
                         if (currentGameState.FlagData.numCarsPassedIllegally == 1)
                         {
                             // don't allow any other message to override this one:
-                            audioPlayer.playMessageImmediately(new QueuedMessage("give_position_back", MessageContents(folderGiveOnePositionBackFirstWarning), 0,
-                                null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("give_position_back", 3,
+                                messageFragments: MessageContents(folderGiveOnePositionBackFirstWarning), type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                         }
                         else
                         {
                             // don't allow any other message to override this one:
-                            audioPlayer.playMessageImmediately(new QueuedMessage("give_positions_back", MessageContents(folderGivePositionsBackFirstWarningIntro,
-                                currentGameState.FlagData.numCarsPassedIllegally, folderGivePositionsBackFirstWarningOutro), 0,
-                                null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("give_positions_back", 0,
+                                messageFragments: MessageContents(folderGivePositionsBackFirstWarningIntro, currentGameState.FlagData.numCarsPassedIllegally, folderGivePositionsBackFirstWarningOutro),
+                                type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                         }
                     }
                 }
@@ -609,8 +611,8 @@ namespace CrewChiefV4.Events
                     if (currentGameState.PenaltiesData.NumPenalties == 0)
                     {
                         // don't allow any other message to override this one:
-                        audioPlayer.playMessageImmediately(new QueuedMessage("give_positions_back_completed", MessageContents(folderGivePositionsBackCompleted), 0,
-                            null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage("give_positions_back_completed", 5,
+                            messageFragments: MessageContents(folderGivePositionsBackCompleted), type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                     }
                     hasAlreadyWarnedAboutIllegalPass = false;
                 }
@@ -627,6 +629,7 @@ namespace CrewChiefV4.Events
                 {
                     lastFCYAnnounced = currentGameState.FlagData.fcyPhase;
                     lastFCYAccountedTime = currentGameState.Now;
+                    int delay = Utilities.random.Next(1, 4);
                     switch (currentGameState.FlagData.fcyPhase)
                     {
                         case FullCourseYellowPhase.PENDING:
@@ -649,44 +652,50 @@ namespace CrewChiefV4.Events
                         case FullCourseYellowPhase.PITS_CLOSED:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsClosedUS : folderFCYellowPitsClosedEU, Utilities.random.Next(1, 4), this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsClosedUS : folderFCYellowPitsClosedEU,
+                                    delay + 6, secondsDelay: delay, abstractEvent: this, priority: 10));
                             }
                             break;
                         case FullCourseYellowPhase.PITS_OPEN_LEAD_LAP_VEHICLES:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenLeadLapCarsUS : folderFCYellowPitsOpenLeadLapCarsEU, Utilities.random.Next(1, 4), this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenLeadLapCarsUS : folderFCYellowPitsOpenLeadLapCarsEU,
+                                    delay + 6, secondsDelay: delay, abstractEvent: this, priority: 10));
                             }
                             break;
                         case FullCourseYellowPhase.PITS_OPEN:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenUS : folderFCYellowPitsOpenEU, Utilities.random.Next(1, 4), this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowPitsOpenUS : folderFCYellowPitsOpenEU,
+                                    delay + 6, secondsDelay: delay, abstractEvent: this, priority: 10));
                             }
                             break;
                         case FullCourseYellowPhase.IN_PROGRESS:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowInProgressUS : folderFCYellowInProgressEU, Utilities.random.Next(1, 4), this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowInProgressUS : folderFCYellowInProgressEU,
+                                    delay + 6, secondsDelay: delay, abstractEvent: this, priority: 10));
                             }
                             break;
                         case FullCourseYellowPhase.LAST_LAP_NEXT:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapNextUS : folderFCYellowLastLapNextEU, Utilities.random.Next(1, 4), this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapNextUS : folderFCYellowLastLapNextEU,
+                                    delay + 6, secondsDelay: delay, abstractEvent: this, priority: 10));
                             }
                             break;
                         case FullCourseYellowPhase.LAST_LAP_CURRENT:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapCurrentUS : folderFCYellowLastLapCurrentEU, Utilities.random.Next(1, 4), this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderFCYellowLastLapCurrentUS : folderFCYellowLastLapCurrentEU,
+                                    delay + 6, secondsDelay: delay, abstractEvent: this, priority: 10));
                             }
                             break;
                         case FullCourseYellowPhase.RACING:
                             // don't allow any other message to override this one:
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage(folderFCYellowGreenFlag, 0, null) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                audioPlayer.playMessageImmediately(new QueuedMessage(folderFCYellowGreenFlag, 0, type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                             }
                             break;
                         default:
@@ -752,8 +761,8 @@ namespace CrewChiefV4.Events
                         {
                             //Console.WriteLine("FLAG_DEBUG: queuing local yellow " + " at " + currentGameState.Now.ToString("HH:mm:ss"));
                             // immediate to prevent it being delayed by the hard-parts logic
-                            audioPlayer.playMessageImmediately(new QueuedMessage(localFlagChangeMessageKey + "_yellow", MessageContents(folderLocalYellow), 1, this,
-                                validationData) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage(localFlagChangeMessageKey + "_yellow", 3, secondsDelay: 1,
+                                messageFragments: MessageContents(folderLocalYellow), abstractEvent: this, validationData: validationData, type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                         }
                     }
                     else if (isUnderLocalYellow && !currentGameState.FlagData.isLocalYellow)
@@ -771,7 +780,8 @@ namespace CrewChiefV4.Events
                         {
                             //Console.WriteLine("FLAG_DEBUG: queuing local green " + " at " + currentGameState.Now.ToString("HH:mm:ss"));
                             audioPlayer.playMessageImmediately(
-                                new QueuedMessage(localFlagChangeMessageKey + "_clear", MessageContents(folderLocalYellowClear), 1, this, validationData) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                new QueuedMessage(localFlagChangeMessageKey + "_clear", 3, secondsDelay: 1,
+                                    messageFragments: MessageContents(folderLocalYellowClear), abstractEvent: this, validationData: validationData, type: SoundType.IMPORTANT_MESSAGE, priority: 10));
                         }
                     }
                     else if (allSectorsAreGreen(currentGameState.FlagData))
@@ -878,16 +888,18 @@ namespace CrewChiefV4.Events
                                         {
                                             //Console.WriteLine("FLAG_DEBUG: queuing sector " + (i + 1) + " " + sectorFlag + " at " + currentGameState.Now.ToString("HH:mm:ss"));
                                             // immediate to prevent it being delayed by the hard-parts logic
-                                            audioPlayer.playMessageImmediately(new QueuedMessage(sectorFlagChangeMessageKeyStart + (i + 1), MessageContents(sectorFlag == FlagEnum.YELLOW ?
-                                                folderYellowFlag : folderDoubleYellowFlag), 3, this, validationData) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                            audioPlayer.playMessageImmediately(new QueuedMessage(sectorFlagChangeMessageKeyStart + (i + 1), 6, secondsDelay: 3,
+                                                messageFragments: MessageContents(sectorFlag == FlagEnum.YELLOW ? folderYellowFlag : folderDoubleYellowFlag), 
+                                                abstractEvent: this, validationData: validationData, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                         }
                                     }
                                     else if (CrewChief.yellowFlagMessagesEnabled && !currentGameState.PitData.InPitlane)
                                     {
                                         //Console.WriteLine("FLAG_DEBUG: queuing sector " + (i + 1) + " " + sectorFlag + " at " + currentGameState.Now.ToString("HH:mm:ss"));
                                         // immediate to prevent it being delayed by the hard-parts logic
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(sectorFlagChangeMessageKeyStart + (i + 1), MessageContents(sectorFlag == FlagEnum.YELLOW ?
-                                            folderYellowFlagSectors[i] : folderDoubleYellowFlagSectors[i]), 3, this, validationData) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(sectorFlagChangeMessageKeyStart + (i + 1), 6, secondsDelay: 3,
+                                            messageFragments: MessageContents(sectorFlag == FlagEnum.YELLOW ? folderYellowFlagSectors[i] : folderDoubleYellowFlagSectors[i]),
+                                            abstractEvent: this, validationData: validationData, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 if (enableOpponentCrashMessages)
@@ -913,8 +925,9 @@ namespace CrewChiefV4.Events
                                         // a duplicate clear for local sectors
                                         //Console.WriteLine("FLAG_DEBUG: queuing sector " + (i + 1) + " " + sectorFlag + " at " + currentGameState.Now.ToString("HH:mm:ss"));
                                         String messageKey = i == currentGameState.SessionData.SectorNumber - 1 ? localFlagChangeMessageKey+ "_clear" : sectorFlagChangeMessageKeyStart + (i + 1);
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(messageKey,
-                                            MessageContents(folderGreenFlagSectors[i]), 3, this, validationData) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(messageKey, 5, secondsDelay: 3,
+                                            messageFragments: MessageContents(folderGreenFlagSectors[i]), 
+                                            abstractEvent: this, validationData: validationData, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                             }
@@ -929,7 +942,7 @@ namespace CrewChiefV4.Events
                     {
                         if (CrewChief.yellowFlagMessagesEnabled)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage(folderClearToOvertake, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage(folderClearToOvertake, 2, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                         lastReportedOvertakeAllowed = PassAllowedUnderYellow.YES;
                         lastOvertakeAllowedReportTime = currentGameState.Now;
@@ -939,7 +952,7 @@ namespace CrewChiefV4.Events
                     {
                         if (CrewChief.yellowFlagMessagesEnabled)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage(folderNoOvertaking, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage(folderNoOvertaking, 2, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                         lastReportedOvertakeAllowed = PassAllowedUnderYellow.NO;
                         lastOvertakeAllowedReportTime = currentGameState.Now;                                               
@@ -1004,7 +1017,7 @@ namespace CrewChiefV4.Events
                     disableYellowFlagUntil = currentGameState.Now.Add(timeBetweenYellowFlagMessages);
                     if (CrewChief.yellowFlagMessagesEnabled)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYellowFlag, 0, this) { metadata = new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYellowFlag, 3, abstractEvent: this, type: SoundType.CRITICAL_MESSAGE, priority: 10));
                     }
                 }
             }
@@ -1017,7 +1030,7 @@ namespace CrewChiefV4.Events
                     disableYellowFlagUntil = currentGameState.Now.Add(timeBetweenYellowFlagMessages);
                     if (CrewChief.yellowFlagMessagesEnabled)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderDoubleYellowFlag, 0, this) { metadata = new SoundMetadata(SoundType.CRITICAL_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderDoubleYellowFlag, 3, abstractEvent: this, type: SoundType.CRITICAL_MESSAGE, priority: 10));
                     }
                 }
             }
@@ -1090,8 +1103,9 @@ namespace CrewChiefV4.Events
                         // report pileup
                         if (CrewChief.yellowFlagMessagesEnabled)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("pileup_in_corner", MessageContents(folderPileupInCornerIntro, "corners/" +
-                                waitingForCrashedDriverInCorner), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("pileup_in_corner", 6, secondsDelay: 3,
+                                messageFragments: MessageContents(folderPileupInCornerIntro, "corners/" +
+                                waitingForCrashedDriverInCorner), abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                     }
                     else
@@ -1133,16 +1147,16 @@ namespace CrewChiefV4.Events
                             Console.WriteLine("Incident in " + waitingForCrashedDriverInCorner + " for drivers " + String.Join(",", namesToDebug));
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage("incident_corner_with_driver", 
-                                    messageContents, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                audioPlayer.playMessageImmediately(new QueuedMessage("incident_corner_with_driver", 4,
+                                    messageFragments: messageContents, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                             }
                         }
                         else if (positionToRead != -1)
                         {
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage("incident_corner_with_driver", MessageContents(
-                                    folderPositionHasGoneOffIn[positionToRead - 1], "corners/" + waitingForCrashedDriverInCorner), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                audioPlayer.playMessageImmediately(new QueuedMessage("incident_corner_with_driver", 4,
+                                    messageFragments: MessageContents(folderPositionHasGoneOffIn[positionToRead - 1], "corners/" + waitingForCrashedDriverInCorner), abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                             }
                         }
                         else
@@ -1150,8 +1164,8 @@ namespace CrewChiefV4.Events
                             Console.WriteLine("Incident in " + waitingForCrashedDriverInCorner);
                             if (CrewChief.yellowFlagMessagesEnabled)
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage("incident_corner", 
-                                    MessageContents(folderIncidentInCornerIntro, "corners/" + waitingForCrashedDriverInCorner), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                audioPlayer.playMessageImmediately(new QueuedMessage("incident_corner", 5,
+                                    messageFragments: MessageContents(folderIncidentInCornerIntro, "corners/" + waitingForCrashedDriverInCorner), abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                             }
                         }
                     }
@@ -1340,7 +1354,7 @@ namespace CrewChiefV4.Events
             if (messageContents.Count > 0 && CrewChief.yellowFlagMessagesEnabled)
             {
                 // immediate to prevent it being delayed by the hard-parts logic
-                audioPlayer.playMessageImmediately(new QueuedMessage("incident_drivers", messageContents, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                audioPlayer.playMessageImmediately(new QueuedMessage("incident_drivers", 5, messageFragments: messageContents, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
             }
         }
 
@@ -1374,8 +1388,8 @@ namespace CrewChiefV4.Events
                         if (CrewChief.yellowFlagMessagesEnabled)
                         {
                             // immediate to prevent it being delayed by the hard-parts logic
-                            audioPlayer.playMessageImmediately(new QueuedMessage("pileup_in_corner", MessageContents(folderPileupInCornerIntro, "corners/" + crashedInLandmarkKey),
-                                0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("pileup_in_corner", 5, messageFragments: MessageContents(folderPileupInCornerIntro, "corners/" + crashedInLandmarkKey),
+                                abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                         return true;
                     }

--- a/CrewChiefV4/Events/FrozenOrderMonitor.cs
+++ b/CrewChiefV4/Events/FrozenOrderMonitor.cs
@@ -171,11 +171,11 @@ namespace CrewChiefV4.Events
             if (pfod.Phase == FrozenOrderPhase.None)
             {
                 Console.WriteLine("Frozen Order: New Phase detected: " + cfod.Phase);
-
+                int delay = Utilities.random.Next(0, 3);
                 if (cfod.Phase == FrozenOrderPhase.Rolling)
-                    audioPlayer.playMessage(new QueuedMessage(folderRollingStartReminder, Utilities.random.Next(0, 3), this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderRollingStartReminder, delay + 4, secondsDelay: delay, abstractEvent: this, priority: 10));
                 else if (cfod.Phase == FrozenOrderPhase.FormationStanding)
-                    audioPlayer.playMessage(new QueuedMessage(folderStandingStartReminder, Utilities.random.Next(0, 3), this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderStandingStartReminder, delay + 4, secondsDelay: delay, abstractEvent: this, priority: 10));
 
                 // Clear previous state.
                 this.clearState();
@@ -240,10 +240,12 @@ namespace CrewChiefV4.Events
                         if (canReadDriverToFollow)
                         { 
                             // Follow messages are only meaningful if there's name to announce.
+                            int delay = Utilities.random.Next(3, 6);
                             if (cfod.AssignedColumn == FrozenOrderColumn.None
                                 || Utilities.random.Next(1, 11) > 8)  // Randomly, announce message without coulmn info.
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car",
-                                    MessageContents(folderFollow, usableDriverNameToFollow), Utilities.random.Next(3, 6), this, validationData), 10);
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car", delay + 6,
+                                    secondsDelay: delay, messageFragments: MessageContents(folderFollow, usableDriverNameToFollow), abstractEvent: this, 
+                                    validationData: validationData, priority: 10));
                             else
                             {
                                 string columnName;
@@ -251,34 +253,43 @@ namespace CrewChiefV4.Events
                                     columnName = cfod.AssignedColumn == FrozenOrderColumn.Left ? folderInTheInsideColumn : folderInTheOutsideColumn;
                                 else
                                     columnName = cfod.AssignedColumn == FrozenOrderColumn.Left ? folderInTheLeftColumn : folderInTheRightColumn;
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_col" : "frozen_order/follow_safecy_car_in_col", MessageContents(folderFollow, usableDriverNameToFollow, columnName), Utilities.random.Next(3, 6), this, validationData), 10);
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_col" : "frozen_order/follow_safecy_car_in_col", delay + 6,
+                                    secondsDelay: delay, messageFragments: MessageContents(folderFollow, usableDriverNameToFollow, columnName), abstractEvent: this,
+                                    validationData: validationData, priority: 10));
                             }
                         }
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.AllowToPass)
                     {
                         // Follow messages are only meaningful if there's name to announce.
+                        int delay = Utilities.random.Next(1, 4);
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
-                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/allow_driver_to_pass" : "frozen_order/allow_safety_car_to_pass",
-                                MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), Utilities.random.Next(1, 4), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/allow_driver_to_pass" : "frozen_order/allow_safety_car_to_pass", delay + 6,
+                                secondsDelay: delay, messageFragments: MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), abstractEvent: this, 
+                                validationData: validationData, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, Utilities.random.Next(1, 4), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, delay + 6, secondsDelay: delay, abstractEvent: this, 
+                                validationData: validationData, priority: 10));
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.CatchUp)
                     {
+                        int delay = Utilities.random.Next(1, 4);
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
-                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/catch_up_to_driver" : "frozen_order/catch_up_to_safety_car",
-                                MessageContents(folderCatchUpTo, usableDriverNameToFollow), Utilities.random.Next(1, 4), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/catch_up_to_driver" : "frozen_order/catch_up_to_safety_car", delay + 6,
+                                secondsDelay: delay, messageFragments: MessageContents(folderCatchUpTo, usableDriverNameToFollow), abstractEvent: this, 
+                                validationData: validationData, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, Utilities.random.Next(1, 4), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, delay + 6, secondsDelay: delay,abstractEvent: this,
+                                validationData: validationData, priority: 10));
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.StayInPole
                         && prevFrozenOrderAction != FrozenOrderAction.MoveToPole)  // No point in nagging user to stay in pole if we previously told them to move there.
                     {
+                        int delay = Utilities.random.Next(0, 3);
                         if (cfod.AssignedColumn == FrozenOrderColumn.None
                             || Utilities.random.Next(1, 11) > 8)  // Randomly, announce message without coulmn info.
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole",
-                                MessageContents(folderStayInPole), Utilities.random.Next(0, 3), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole", delay + 6, secondsDelay: delay,
+                                messageFragments: MessageContents(folderStayInPole), abstractEvent: this, validationData: validationData, priority: 10));
                         else
                         {
                             string folderToPlay = null;
@@ -287,17 +298,21 @@ namespace CrewChiefV4.Events
                             else
                                 folderToPlay = cfod.AssignedColumn == FrozenOrderColumn.Left ? folderStayInPoleInLeftColumn : folderStayInPoleInRightColumn;
 
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole_in_column", MessageContents(folderToPlay), Utilities.random.Next(0, 3), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/stay_in_pole_in_column", delay + 6, secondsDelay: delay,
+                                messageFragments: MessageContents(folderToPlay), abstractEvent: this, validationData: validationData, priority: 10));
                         }
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.MoveToPole)
                     {
+                        int delay = Utilities.random.Next(2, 5);
                         if (cfod.AssignedColumn == FrozenOrderColumn.None)
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/move_to_pole",
-                                MessageContents(folderMoveToPole), Utilities.random.Next(2, 5), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/move_to_pole", delay + 6, secondsDelay: delay,
+                                messageFragments: MessageContents(folderMoveToPole), abstractEvent: this, 
+                                validationData: validationData, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/move_to_pole_row",
-                                MessageContents(folderMoveToPoleRow), Utilities.random.Next(2, 5), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/move_to_pole_row", delay + 6, secondsDelay: delay,
+                                messageFragments: MessageContents(folderMoveToPoleRow), abstractEvent: this,
+                                validationData: validationData, priority: 10));
                     }
                 }
             }
@@ -337,37 +352,50 @@ namespace CrewChiefV4.Events
                         && ((prevDriverToFollow != this.currDriverToFollow)  // Don't announce Follow messages for the driver that we caught up to or allowed to pass.
                             || (prevFrozenOrderColumn != this.currFrozenOrderColumn && announceSCRLastFCYLapLane)))  // But announce for SCR last FCY lap.
                     {
+                        int delay = Utilities.random.Next(0, 3);
                         if (canReadDriverToFollow)
                         {
                             if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Left)
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_left" : "frozen_order/follow_safety_car_in_left", MessageContents(folderFollow, usableDriverNameToFollow,
-                                    useOvalLogic ? folderInTheInsideColumn : folderInTheLeftColumn), Utilities.random.Next(0, 3), this, validationData), 10);
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_left" : "frozen_order/follow_safety_car_in_left",
+                                    delay + 6, secondsDelay: delay, messageFragments: MessageContents(folderFollow, usableDriverNameToFollow,
+                                    useOvalLogic ? folderInTheInsideColumn : folderInTheLeftColumn), abstractEvent: this, validationData: validationData, priority: 10));
                             else if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Right)
                                 audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver_in_right" : "frozen_order/follow_safety_car_in_right",
-                                    MessageContents(folderFollow, usableDriverNameToFollow, useOvalLogic ? folderInTheOutsideColumn : folderInTheRightColumn), Utilities.random.Next(0, 3), this, validationData), 10);
+                                    delay + 6, secondsDelay: delay, 
+                                    messageFragments: MessageContents(folderFollow, usableDriverNameToFollow, useOvalLogic ? folderInTheOutsideColumn : folderInTheRightColumn),
+                                    abstractEvent: this, validationData: validationData, priority: 10));
                             else
-                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car", MessageContents(folderFollow, usableDriverNameToFollow), Utilities.random.Next(0, 3), this, validationData), 10);
+                                audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/follow_driver" : "frozen_order/follow_safety_car", delay + 6, 
+                                    secondsDelay: delay, messageFragments: MessageContents(folderFollow, usableDriverNameToFollow), abstractEvent: this, validationData: validationData, priority: 10));
                         }
                         else if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Left)
-                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInInsideColumn : folderLineUpInLeftColumn, Utilities.random.Next(0, 3), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInInsideColumn : folderLineUpInLeftColumn, delay + 6, secondsDelay: delay,
+                                abstractEvent: this, validationData: validationData, priority: 10));
                         else if (announceSCRLastFCYLapLane && cfod.AssignedColumn == FrozenOrderColumn.Right)
-                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInOutsideColumn : folderLineUpInRightColumn, Utilities.random.Next(0, 3), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(useOvalLogic ? folderLineUpInOutsideColumn : folderLineUpInRightColumn, delay + 6, secondsDelay: delay,
+                                abstractEvent: this, validationData: validationData, priority: 10));
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.AllowToPass)
                     {
+                        int delay = Utilities.random.Next(1, 4);
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
                             audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/allow_driver_to_pass" : "frozen_order/allow_safety_car_to_pass",
-                                MessageContents(folderAllow, usableDriverNameToFollow, folderToPass), Utilities.random.Next(1, 4), this, validationData), 10);
+                                delay + 6, secondsDelay: delay, messageFragments: MessageContents(folderAllow, usableDriverNameToFollow, folderToPass),
+                                abstractEvent: this, validationData: validationData, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, Utilities.random.Next(1, 4), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderYoureAheadOfAGuyYouShouldBeFollowing, delay + 6, secondsDelay: delay, abstractEvent: this,
+                                validationData: validationData, priority: 10));
                     }
                     else if (this.newFrozenOrderAction == FrozenOrderAction.CatchUp)
                     {
+                        int delay = Utilities.random.Next(1, 4);
                         if (canReadDriverToFollow && Utilities.random.Next(1, 11) > 2)  // Randomly, announce message without name.
                             audioPlayer.playMessage(new QueuedMessage(!shouldFollowSafetyCar ? "frozen_order/catch_up_to_driver" : "frozen_order/catch_up_to_safety_car",
-                                MessageContents(folderCatchUpTo, usableDriverNameToFollow), Utilities.random.Next(1, 4), this, validationData), 10);
+                                delay + 6, secondsDelay: delay, messageFragments: MessageContents(folderCatchUpTo, usableDriverNameToFollow), 
+                                abstractEvent: this, validationData: validationData, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, Utilities.random.Next(1, 4), this, validationData), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderYouNeedToCatchUpToTheGuyAhead, delay + 6, secondsDelay: delay, abstractEvent: this,
+                                validationData: validationData, priority: 10));
                     }
                 }
             }
@@ -385,22 +413,24 @@ namespace CrewChiefV4.Events
                 {
                     this.formationStandingStartAnnounced = true;
                     var isStartingFromPole = cfod.AssignedPosition == 1;
+                    int delay = Utilities.random.Next(0, 3);
                     if (isStartingFromPole)
                     {
                         if (columnName == null)
-                            audioPlayer.playMessage(new QueuedMessage(folderWereStartingFromPole, 0, this));
+                            audioPlayer.playMessage(new QueuedMessage(folderWereStartingFromPole, 6, abstractEvent: this));
                         else
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pole_in_column",
-                                    MessageContents(folderWereStartingFromPole, columnName), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pole_in_column", delay + 6, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderWereStartingFromPole, columnName), abstractEvent: this, priority: 10));
                     }
                     else
                     {
                         if (columnName == null)
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pos",
-                                    MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pos", delay + 6, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition), abstractEvent: this, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pos_row_in_column",
-                                    MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/youre_starting_from_pos_row_in_column", delay + 6, secondsDelay: delay, 
+                                    messageFragments: MessageContents(folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName),
+                                    abstractEvent: this, priority: 10));
                     }
                 }
 
@@ -410,23 +440,25 @@ namespace CrewChiefV4.Events
                 {
                     this.formationStandingPreStartReminderAnnounced = true;
                     var isStartingFromPole = cfod.AssignedPosition == 1;
+                    int delay = Utilities.random.Next(0, 3);
                     if (isStartingFromPole)
                     {
                         if (columnName == null)
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_starting_from_pole",
-                                    MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_starting_from_pole", delay + 6, secondsDelay: delay,
+                                    messageFragments: MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole), abstractEvent: this, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_starting_from_pole_in_column",
-                                    MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole, columnName), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_starting_from_pole_in_column", delay + 6, secondsDelay: delay,
+                                    messageFragments: MessageContents(LapCounter.folderGetReady, folderWereStartingFromPole, columnName), abstractEvent: this, priority: 10));
                     }
                     else
                     {
                         if (columnName == null)
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_youre_starting_from_pos",
-                                    MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_youre_starting_from_pos", delay + 6, secondsDelay: delay,
+                                    messageFragments: MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition), abstractEvent: this, priority: 10));
                         else
-                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_youre_starting_from_pos_row_in_column",
-                                    MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), Utilities.random.Next(0, 3), this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("frozen_order/get_ready_youre_starting_from_pos_row_in_column", delay+ 6, secondsDelay: delay,
+                                    messageFragments: MessageContents(LapCounter.folderGetReady, folderWeStartingFromPosition, cfod.AssignedPosition, folderRow, cfod.AssignedGridPosition, columnName), 
+                                    abstractEvent: this, priority: 10));
                     }
                 }
             }
@@ -450,16 +482,17 @@ namespace CrewChiefV4.Events
                     messageFragments.Add(MessageFragment.Integer((int)Math.Round(kmPerHour), false));
                     messageFragments.Add(MessageFragment.Text(FrozenOrderMonitor.folderKilometresPerHour));
                 }
-                audioPlayer.playMessage(new QueuedMessage("frozen_order/pace_car_speed", messageFragments, Utilities.random.Next(10, 16), this), 10);
+                int delay = Utilities.random.Next(10, 16);
+                audioPlayer.playMessage(new QueuedMessage("frozen_order/pace_car_speed", delay + 6, secondsDelay: delay, messageFragments: messageFragments, abstractEvent: this, priority: 10));
             }
 
             // Announce SC left.
             if (pfod.SafetyCarSpeed != -1.0f && cfod.SafetyCarSpeed == -1.0f)
             {
                 if (useAmericanTerms)
-                    audioPlayer.playMessage(new QueuedMessage(folderPaceCarJustLeft, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderPaceCarJustLeft, 10, abstractEvent: this));
                 else
-                    audioPlayer.playMessage(new QueuedMessage(folderSafetyCarJustLeft, 0, this));
+                    audioPlayer.playMessage(new QueuedMessage(folderSafetyCarJustLeft, 10, abstractEvent: this));
             }
 
             // For fast rolling, do nothing for now.

--- a/CrewChiefV4/Events/Fuel.cs
+++ b/CrewChiefV4/Events/Fuel.cs
@@ -452,13 +452,13 @@ namespace CrewChiefV4.Events
                             {
                                 // yes i know its not 2 liters but who really cares.
                                 played2LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderOneGallonRemaining), 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderOneGallonRemaining), abstractEvent: this, priority: 10));
                             }
                             else if (convertLitersToGallons(currentFuel) <= 0.5f && !played1LitreWarning)
                             {
                                 //^^
                                 played1LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderHalfAGallonRemaining), 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderHalfAGallonRemaining), abstractEvent: this, priority: 10));
                             }
                         }
                         else
@@ -466,12 +466,12 @@ namespace CrewChiefV4.Events
                             if (currentFuel <= 2 && !played2LitreWarning)
                             {
                                 played2LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(2, folderLitresRemaining), 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(2, folderLitresRemaining), abstractEvent: this, priority: 10));
                             }
                             else if (currentFuel <= 1 && !played1LitreWarning)
                             {
                                 played1LitreWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", MessageContents(folderOneLitreRemaining), 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderOneLitreRemaining), abstractEvent: this, priority: 10));
                             }
                         }
 
@@ -490,17 +490,17 @@ namespace CrewChiefV4.Events
                                 {
                                     if (currentGameState.PitData.IsRefuellingAllowed)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 7);
-                                        audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", MessageContents(folderWeEstimate, estimatedFuelLapsLeft, folderLapsRemaining), 0, this), 7);
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", 0,
+                                            messageFragments: MessageContents(RaceTime.folderHalfWayHome, folderWeEstimate, estimatedFuelLapsLeft, folderLapsRemaining), abstractEvent: this, priority: 7));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, this), 7);
+                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, abstractEvent: this, priority: 7));
                                     }
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 5);
+                                    audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, abstractEvent: this, priority: 5));
                                 }
                             }
                             else if (lapsRemaining > 3 && estimatedFuelLapsLeft == 4)
@@ -515,7 +515,7 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("4 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));  
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderFourLapsEstimate, 0, this), 3);
+                                audioPlayer.playMessage(new QueuedMessage(folderFourLapsEstimate, 0, abstractEvent: this, priority: 3));
                             }
                             else if (lapsRemaining > 2 && estimatedFuelLapsLeft == 3)
                             {
@@ -529,7 +529,7 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("3 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderThreeLapsEstimate, 0, this), 5);
+                                audioPlayer.playMessage(new QueuedMessage(folderThreeLapsEstimate, 0, abstractEvent: this, priority: 5));
                             }
                             else if (lapsRemaining > 1 && estimatedFuelLapsLeft == 2)
                             {
@@ -543,7 +543,7 @@ namespace CrewChiefV4.Events
                                     Console.WriteLine("2 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderTwoLapsEstimate, 0, this), 7);
+                                audioPlayer.playMessage(new QueuedMessage(folderTwoLapsEstimate, 0, abstractEvent: this, priority: 7));
                             }
                             else if (lapsRemaining > 0 && estimatedFuelLapsLeft == 1)
                             {
@@ -556,14 +556,14 @@ namespace CrewChiefV4.Events
                                 {
                                     Console.WriteLine("1 laps fuel left, starting fuel = " + initialFuelLevel.ToString("0.000") +
                                             ", current fuel = " + currentGameState.FuelData.FuelLeft.ToString("0.000") + ", usage per lap = " + averageUsagePerLap.ToString("0.000"));
-                                }                                
-                                audioPlayer.playMessage(new QueuedMessage(folderOneLapEstimate, 0, this), 10);
+                                }
+                                audioPlayer.playMessage(new QueuedMessage(folderOneLapEstimate, 0, abstractEvent: this, priority: 10));
                                 // if we've not played the pit-now message, play it with a bit of a delay - should probably wait for sector3 here
                                 // but i'd have to move some stuff around and I'm an idle fucker
                                 if (!playedPitForFuelNow && lapsRemaining > 1)
                                 {
                                     playedPitForFuelNow = true;
-                                    audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 10, this), 10);
+                                    audioPlayer.playMessage(new QueuedMessage(PitStops.folderMandatoryPitStopsPitThisLap, 0, secondsDelay: 10, abstractEvent: this, priority: 7));
                                 }
                             }
                         }
@@ -600,23 +600,22 @@ namespace CrewChiefV4.Events
                                         if (currentGameState.PitData.IsRefuellingAllowed)
                                         {
                                             int minutesLeft = (int)Math.Floor(currentGameState.FuelData.FuelLeft / averageUsagePerMinute);
-                                            audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 7);
-                                            audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", MessageContents(
-                                                folderWeEstimate, minutesLeft, folderMinutesRemaining), 0, this), 7);
+                                            audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", 0,
+                                                messageFragments: MessageContents(RaceTime.folderHalfWayHome, folderWeEstimate, minutesLeft, folderMinutesRemaining), abstractEvent: this, priority: 7));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, this), 7);
+                                            audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceLowFuel, 0, abstractEvent: this, priority: 7));
                                         }
                                     }
                                     else if (currentGameState.FuelData.FuelLeft - fuelToEnd <= 2)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(RaceTime.folderHalfWayHome, 0, this), 7);
-                                        audioPlayer.playMessage(new QueuedMessage(folderFuelWillBeTight, 0, this));
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/estimate", 0,
+                                            messageFragments: MessageContents(RaceTime.folderHalfWayHome, folderFuelWillBeTight), abstractEvent: this, priority: 7));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, this), 5);
+                                        audioPlayer.playMessage(new QueuedMessage(folderHalfDistanceGoodFuel, 0, abstractEvent: this, priority: 7));
                                     }
                                 }
                             }
@@ -640,13 +639,13 @@ namespace CrewChiefV4.Events
                                 {
                                     if (currentGameState.SessionData.SessionTimeRemaining > cutoffForRefuelCall)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("pit_for_fuel_now",
-                                            MessageContents(folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), 0, this), 10);
+                                        audioPlayer.playMessage(new QueuedMessage("pit_for_fuel_now", 0,
+                                            messageFragments: MessageContents(folderAboutToRunOut, PitStops.folderMandatoryPitStopsPitThisLap), abstractEvent: this, priority: 10));
                                     }
                                     else
                                     {
                                         // going to run out, but don't call the player into the pits - it's up to him
-                                        audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_fuel", MessageContents(folderAboutToRunOut), 0, this), 10);
+                                        audioPlayer.playMessage(new QueuedMessage("about_to_run_out_of_fuel", 0, messageFragments: MessageContents(folderAboutToRunOut), abstractEvent: this, priority: 10));
                                     }
                                 }
                             }
@@ -655,18 +654,18 @@ namespace CrewChiefV4.Events
                                 playedTwoMinutesRemaining = true;
                                 playedFiveMinutesRemaining = true;
                                 playedTenMinutesRemaining = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderTwoMinutesFuel, 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderTwoMinutesFuel, 0, abstractEvent: this, priority: 10));
                             }
                             else if (estimatedFuelMinutesLeft <= 5 && estimatedFuelMinutesLeft > 4.8 && !playedFiveMinutesRemaining)
                             {
                                 playedFiveMinutesRemaining = true;
                                 playedTenMinutesRemaining = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderFiveMinutesFuel, 0, this), 7);
+                                audioPlayer.playMessage(new QueuedMessage(folderFiveMinutesFuel, 0, abstractEvent: this, priority: 7));
                             }
                             else if (estimatedFuelMinutesLeft <= 10 && estimatedFuelMinutesLeft > 9.8 && !playedTenMinutesRemaining)
                             {
                                 playedTenMinutesRemaining = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderTenMinutesFuel, 0, this), 3);
+                                audioPlayer.playMessage(new QueuedMessage(folderTenMinutesFuel, 0, abstractEvent: this, priority: 3));
 
                             }
                             else if (!playedHalfTankWarning && currentGameState.FuelData.FuelLeft / initialFuelLevel <= 0.50 && 
@@ -674,7 +673,7 @@ namespace CrewChiefV4.Events
                             {
                                 // warning message for fuel left - these play as soon as the fuel reaches 1/2 tank left
                                 playedHalfTankWarning = true;
-                                audioPlayer.playMessage(new QueuedMessage(folderHalfTankWarning, 0, this), 0);
+                                audioPlayer.playMessage(new QueuedMessage(folderHalfTankWarning, 0, abstractEvent: this, priority: 0));
                             }
                         }
 
@@ -713,14 +712,13 @@ namespace CrewChiefV4.Events
                                     // if item1 is < current minute but item2 is sensible, we want to say "pit window for fuel closes after X laps"
                                     else if (predictedWindow.Item1 < currentGameState.SessionData.CompletedLaps)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel",
-                                            MessageContents(folderWillNeedToPitForFuelByLap, predictedWindow.Item2), Utilities.random.Next(8), null));
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel", 0, secondsDelay: Utilities.random.Next(8),
+                                            messageFragments: MessageContents(folderWillNeedToPitForFuelByLap, predictedWindow.Item2)));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel",
-                                            MessageContents(folderFuelWindowOpensOnLap, predictedWindow.Item1,
-                                            folderAndFuelWindowClosesOnLap, predictedWindow.Item2), Utilities.random.Next(8), null));
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel", 0, secondsDelay: Utilities.random.Next(8),
+                                            messageFragments: MessageContents(folderFuelWindowOpensOnLap, predictedWindow.Item1, folderAndFuelWindowClosesOnLap, predictedWindow.Item2)));
                                     }
                                 }
                                 else
@@ -733,18 +731,14 @@ namespace CrewChiefV4.Events
                                     // if item1 is < current minute, we want to say "pit window for fuel closes after X minutes"
                                     else if (predictedWindow.Item1 < currentGameState.SessionData.SessionRunningTime / 60)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel",
-                                            MessageContents(folderWillNeedToPitForFuelByTimeIntro,
-                                            TimeSpanWrapper.FromMinutes(predictedWindow.Item2, Precision.MINUTES),
-                                            folderWillNeedToPitForFuelByTimeOutro), Utilities.random.Next(8), null));
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel", 0, secondsDelay: Utilities.random.Next(8),
+                                            messageFragments: MessageContents(folderWillNeedToPitForFuelByTimeIntro, TimeSpanWrapper.FromMinutes(predictedWindow.Item2, Precision.MINUTES), folderWillNeedToPitForFuelByTimeOutro)));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel",
-                                            MessageContents(folderFuelWindowOpensAfterTime,
-                                            TimeSpanWrapper.FromMinutes(predictedWindow.Item1, Precision.MINUTES),
-                                            folderAndFuelWindowClosesAfterTime,
-                                            TimeSpanWrapper.FromMinutes(predictedWindow.Item2, Precision.MINUTES)), Utilities.random.Next(8), null));
+                                        audioPlayer.playMessage(new QueuedMessage("Fuel/pit_window_for_fuel", 0, secondsDelay: Utilities.random.Next(8),
+                                            messageFragments: MessageContents(folderFuelWindowOpensAfterTime, TimeSpanWrapper.FromMinutes(predictedWindow.Item1, Precision.MINUTES),
+                                            folderAndFuelWindowClosesAfterTime,  TimeSpanWrapper.FromMinutes(predictedWindow.Item2, Precision.MINUTES))));
                                     }
                                 }
                             }
@@ -779,26 +773,26 @@ namespace CrewChiefV4.Events
                     {
                         if (fuelReportsInGallon)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap",
-                                    MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderGallonsPerLap), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap", 0,
+                                    messageFragments: MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderGallonsPerLap)));
                         }
                         else
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap",
-                                    MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderLitresPerLap), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap", 0,
+                                    messageFragments: MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderLitresPerLap)));
                         }
                     }
                     else
                     {
                         if (fuelReportsInGallon)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap",
-                                    MessageContents(wholeandfractional.Item1, folderGallonsPerLap), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap", 0,
+                                    messageFragments: MessageContents(wholeandfractional.Item1, folderGallonsPerLap)));
                         }
                         else
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap",
-                                    MessageContents(wholeandfractional.Item1, folderLitresPerLap), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/mean_use_per_lap", 0,
+                                    messageFragments: MessageContents(wholeandfractional.Item1, folderLitresPerLap)));
                         }
                     }
                 }
@@ -852,12 +846,12 @@ namespace CrewChiefV4.Events
                         messageFragments.Add(MessageFragment.Integer(usage, false));
                         messageFragments.Add(MessageFragment.Text(usage == 1 ? folderLitre : folderLitres));
                     }
-                    QueuedMessage fuelEstimateMessage = new QueuedMessage("Fuel/estimate", messageFragments, 0, null);
+                    QueuedMessage fuelEstimateMessage = new QueuedMessage("Fuel/estimate", 0, messageFragments: messageFragments);
 
                     // play this immediately or play "stand by", and queue it to be played in a few seconds
                     if (delayResponses && Utilities.random.Next(10) >= 2 && SoundCache.availableSounds.Contains(AudioPlayer.folderStandBy))
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderStandBy, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderStandBy, 0));
                         int secondsDelay = Math.Max(5, Utilities.random.Next(7));
                         audioPlayer.pauseQueue(secondsDelay);
                         fuelEstimateMessage.secondsDelay = secondsDelay;
@@ -918,8 +912,7 @@ namespace CrewChiefV4.Events
                         messageFragments.Add(MessageFragment.Text(usage == 1 ? folderLitre : folderLitres));
                     }
 
-                    QueuedMessage fuelEstimateMessage = new QueuedMessage("Fuel/estimate",
-                            messageFragments, 0, null);
+                    QueuedMessage fuelEstimateMessage = new QueuedMessage("Fuel/estimate", 0, messageFragments: messageFragments);
                     // play this immediately or play "stand by", and queue it to be played in a few seconds
                     if (delayResponses && Utilities.random.Next(10) >= 2 && SoundCache.availableSounds.Contains(AudioPlayer.folderStandBy))
                     {
@@ -948,8 +941,7 @@ namespace CrewChiefV4.Events
                     int lapsOfFuelLeft = (int)Math.Floor(currentFuel / averageUsagePerLap);
                     if (lapsOfFuelLeft <= 1)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate",
-                            MessageContents(folderAboutToRunOut), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate", 0, messageFragments: MessageContents(folderAboutToRunOut)));
                     }
                     else
                     {
@@ -957,7 +949,7 @@ namespace CrewChiefV4.Events
                         messageFragments.Add(MessageFragment.Text(folderWeEstimate));
                         messageFragments.Add(MessageFragment.Integer(lapsOfFuelLeft, false));
                         messageFragments.Add(MessageFragment.Text(folderLapsRemaining));
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate", messageFragments, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate", 0, messageFragments: messageFragments));
                     }                    
                 }
                 else if (averageUsagePerMinute > 0)
@@ -966,8 +958,7 @@ namespace CrewChiefV4.Events
                     int minutesOfFuelLeft = (int)Math.Floor(currentFuel / averageUsagePerMinute);
                     if (minutesOfFuelLeft <= 1)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate",
-                            MessageContents(folderAboutToRunOut), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate", 0, messageFragments: MessageContents(folderAboutToRunOut)));
                     }
                     else
                     {
@@ -975,7 +966,7 @@ namespace CrewChiefV4.Events
                         messageFragments.Add(MessageFragment.Text(folderWeEstimate));
                         messageFragments.Add(MessageFragment.Integer(minutesOfFuelLeft, false));
                         messageFragments.Add(MessageFragment.Text(folderMinutesRemaining));
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate", messageFragments, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/estimate", 0, messageFragments:messageFragments));
                     }                    
                 }
             }
@@ -1005,25 +996,22 @@ namespace CrewChiefV4.Events
                             messageFragments.Add(MessageFragment.Integer(Convert.ToInt32(wholeandfractional.Item1), false));
                             messageFragments.Add(MessageFragment.Text(folderGallonsRemaining));
                         }
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", messageFragments, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: messageFragments));
                     }
                     else if (convertLitersToGallons(currentFuel) >= 1)
                     {
                         haveData = true;
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level",
-                                    MessageContents(folderOneGallonRemaining), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderOneGallonRemaining)));
                     }
                     else if (convertLitersToGallons(currentFuel) > 0.5f)
                     {
                         haveData = true;
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level",
-                                MessageContents(folderHalfAGallonRemaining), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderHalfAGallonRemaining)));
                     }
                     else if (convertLitersToGallons(currentFuel) > 0)
                     {
                         haveData = true;
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level",
-                                MessageContents(folderAboutToRunOut), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderAboutToRunOut)));
                     }
                 }
                 else
@@ -1034,19 +1022,17 @@ namespace CrewChiefV4.Events
                         List<MessageFragment> messageFragments = new List<MessageFragment>();
                         messageFragments.Add(MessageFragment.Integer((int)currentFuel, false));
                         messageFragments.Add(MessageFragment.Text(folderLitresRemaining));
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", messageFragments, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: messageFragments));
                     }
                     else if (currentFuel >= 1)
                     {
                         haveData = true;
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level",
-                                    MessageContents(folderOneLitreRemaining), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderOneLitreRemaining)));
                     }
                     else if (currentFuel > 0)
                     {
                         haveData = true;
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level",
-                                MessageContents(folderAboutToRunOut), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents(folderAboutToRunOut)));
                     }
                 }
 
@@ -1140,20 +1126,20 @@ namespace CrewChiefV4.Events
                                 Tuple<int, int> wholeandfractional = Utilities.WholeAndFractionalPart(gallonsNeeded);
                                 if (wholeandfractional.Item2 > 0)
                                 {
-                                    fuelMessage = new QueuedMessage("fuel_estimate_to_end", MessageContents(folderWillNeedToAdd,
-                                        wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderGallonsToGetToTheEnd), 0, null);
+                                    fuelMessage = new QueuedMessage("fuel_estimate_to_end", 0, messageFragments: MessageContents(folderWillNeedToAdd,
+                                        wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderGallonsToGetToTheEnd));
                                 }
                                 else
                                 {
                                     int wholeGallons = Convert.ToInt32(wholeandfractional.Item1);
-                                    fuelMessage = new QueuedMessage("fuel_estimate_to_end", MessageContents(wholeGallons, wholeGallons == 1 ?
-                                        folderWillNeedToAddOneGallonToGetToTheEnd : folderWillNeedToAdd, wholeGallons, folderGallonsToGetToTheEnd), 0, null);
+                                    fuelMessage = new QueuedMessage("fuel_estimate_to_end", 0, messageFragments: MessageContents(wholeGallons, wholeGallons == 1 ?
+                                        folderWillNeedToAddOneGallonToGetToTheEnd : folderWillNeedToAdd, wholeGallons, folderGallonsToGetToTheEnd));
                                 }
                             }
                             else
                             {
-                                fuelMessage = new QueuedMessage("fuel_estimate_to_end", MessageContents(folderWillNeedToAdd,
-                                    (int) Math.Ceiling(litresToEnd), folderLitresToGetToTheEnd), 0, null);
+                                fuelMessage = new QueuedMessage("fuel_estimate_to_end", 0, messageFragments: MessageContents(folderWillNeedToAdd,
+                                    (int) Math.Ceiling(litresToEnd), folderLitresToGetToTheEnd));
                             }
                         }
                     }
@@ -1213,7 +1199,7 @@ namespace CrewChiefV4.Events
         {
             if (!GlobalBehaviourSettings.enabledMessageTypes.Contains(MessageTypes.FUEL))
             {
-                this.audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                this.audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
 
                 return;
             }
@@ -1222,23 +1208,22 @@ namespace CrewChiefV4.Events
             {
                 if (!reportFuelConsumption())
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));                    
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHATS_MY_FUEL_LEVEL))
             {
                 if (!fuelUseActive)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 }
                 else if (currentFuel >= 2)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level",
-                                MessageContents((int)currentFuel, folderLitresRemaining), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("Fuel/level", 0, messageFragments: MessageContents((int)currentFuel, folderLitresRemaining)));
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderAboutToRunOut, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderAboutToRunOut, 0));
                 }
             }            
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.HOW_MUCH_FUEL_TO_END_OF_RACE))
@@ -1247,17 +1232,17 @@ namespace CrewChiefV4.Events
                 float fuelToBeSafe = getMinFuelRemainingToBeConsideredSafe();
                 if (!fuelUseActive || litresNeeded == float.MaxValue)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 } 
                 else if (litresNeeded < 0)
                 {
                     if (litresNeeded * -1 > fuelToBeSafe)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderPlentyOfFuel, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderPlentyOfFuel, 0));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFuelShouldBeOK, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFuelShouldBeOK, 0));
                     }
                 }
                 else
@@ -1270,18 +1255,19 @@ namespace CrewChiefV4.Events
                         Tuple<int, int> wholeandfractional = Utilities.WholeAndFractionalPart(gallonsNeeded);
                         if (wholeandfractional.Item2 > 0)
                         {
-                            fuelMessage = new QueuedMessage("fuel_estimate_to_end", MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderGallons), 0, null);
+                            fuelMessage = new QueuedMessage("fuel_estimate_to_end", 0,
+                                messageFragments: MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2, folderGallons));
                         }
                         else
                         {
                             int wholeGallons = Convert.ToInt32(wholeandfractional.Item1);
-                            fuelMessage = new QueuedMessage("fuel_estimate_to_end", MessageContents(wholeGallons, wholeGallons == 1 ? folderGallon : folderGallons), 0, null);
+                            fuelMessage = new QueuedMessage("fuel_estimate_to_end", 0, messageFragments: MessageContents(wholeGallons, wholeGallons == 1 ? folderGallon : folderGallons));
                         }
                     }
                     else
                     {
                         int roundedLitresNeeded = (int) Math.Ceiling(litresNeeded);
-                        fuelMessage = new QueuedMessage("fuel_estimate_to_end", MessageContents(roundedLitresNeeded, roundedLitresNeeded == 1 ? folderLitre : folderLitres), 0, null);
+                        fuelMessage = new QueuedMessage("fuel_estimate_to_end", 0, messageFragments: MessageContents(roundedLitresNeeded, roundedLitresNeeded == 1 ? folderLitre : folderLitres));
                     }
                     if (delayResponses && Utilities.random.Next(10) >= 2 && SoundCache.availableSounds.Contains(AudioPlayer.folderStandBy))
                     {
@@ -1506,7 +1492,7 @@ namespace CrewChiefV4.Events
             if (fuelCapacityInt > 0 && fuelCapacityInt - currentFuel < litresToEnd)
             {
                 // if we have a known fuel capacity and this is less than the calculated amount of fuel we need, warn about it.
-                audioPlayer.playMessage(new QueuedMessage(folderWillNeedToStopAgain, 4, this), 10);
+                audioPlayer.playMessage(new QueuedMessage(folderWillNeedToStopAgain, 0, secondsDelay: 4, abstractEvent: this, priority: 10));
             }
             int maxPresses = fuelCapacityInt > 0 ? fuelCapacityInt : 200;
             return litresToEnd == -1 ? 0 : litresToEnd > maxPresses ? maxPresses : litresToEnd;

--- a/CrewChiefV4/Events/IRacingBroadcastMessageEvent.cs
+++ b/CrewChiefV4/Events/IRacingBroadcastMessageEvent.cs
@@ -121,11 +121,11 @@ namespace CrewChiefV4.Events
 
                     if (litresNeeded == float.MaxValue)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                        audioPlayer.playMessage(new QueuedMessage(AudioPlayer.folderNoData, 0));
                     }
                     else if (litresNeeded <= 0)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(Fuel.folderPlentyOfFuel, 0, null));
+                        audioPlayer.playMessage(new QueuedMessage(Fuel.folderPlentyOfFuel, 0));
                     }
                     else if (litresNeeded > 0)
                     {
@@ -135,11 +135,11 @@ namespace CrewChiefV4.Events
                         if (roundedLitresNeeded > fuelCapacity - currentFuel)
                         {
                             // if we have a known fuel capacity and this is less than the calculated amount of fuel we need, warn about it.
-                            audioPlayer.playMessage(new QueuedMessage(Fuel.folderWillNeedToStopAgain, 4, this));
+                            audioPlayer.playMessage(new QueuedMessage(Fuel.folderWillNeedToStopAgain, 0, secondsDelay: 4, abstractEvent: this));
                         }
                         else
                         {
-                            audioPlayer.playMessage(new QueuedMessage(AudioPlayer.folderFuelToEnd, 0, null));
+                            audioPlayer.playMessage(new QueuedMessage(AudioPlayer.folderFuelToEnd, 0));
                         }
                     }
                 }
@@ -188,14 +188,14 @@ namespace CrewChiefV4.Events
                 if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.LITERS))
                 {
                     AddFuel(amount);
-                    audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel",
-                        MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderLitre : Fuel.folderLitres), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel", 0,
+                        messageFragments: MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderLitre : Fuel.folderLitres)));
                 }
                 else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.GALLONS))
                 {
                     AddFuel(convertGallonsToLitres(amount));
-                    audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel",
-                        MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderGallon : Fuel.folderGallons), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel", 0,
+                        messageFragments: MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderGallon : Fuel.folderGallons)));
                 }
                 else
                 {
@@ -203,14 +203,14 @@ namespace CrewChiefV4.Events
                     if (!Fuel.fuelReportsInGallon)
                     {
                         AddFuel(amount);
-                        audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel",
-                            MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderLitre : Fuel.folderLitres), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel", 0,
+                            messageFragments: MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderLitre : Fuel.folderLitres)));
                     }
                     else
                     {
                         AddFuel(convertGallonsToLitres(amount));
-                        audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel",
-                            MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderGallon : Fuel.folderGallons), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("iracing_add_fuel", 0,
+                            messageFragments: MessageContents(AudioPlayer.folderAcknowlegeOK, amount, amount == 1 ? Fuel.folderGallon : Fuel.folderGallons)));
                     }
                 }
                 return;
@@ -235,11 +235,11 @@ namespace CrewChiefV4.Events
                     if (roundedLitresNeeded > fuelCapacity - currentFuel) 
                     {
                         // if we have a known fuel capacity and this is less than the calculated amount of fuel we need, warn about it.
-                        audioPlayer.playMessage(new QueuedMessage(Fuel.folderWillNeedToStopAgain, 4, this));
+                        audioPlayer.playMessage(new QueuedMessage(Fuel.folderWillNeedToStopAgain, 0, secondsDelay: 4, abstractEvent: this));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderFuelToEnd, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderFuelToEnd, 0));
                     }                    
                     return;
                 }
@@ -248,43 +248,43 @@ namespace CrewChiefV4.Events
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_TEAROFF))
             {
                 Tearoff();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_FAST_REPAIR))
             {
                 FastRepair();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CLEAR_ALL))
             {
                 ClearAll();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CLEAR_TYRES))
             {
                 ClearTires();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CLEAR_WIND_SCREEN))
             {
                 ClearTearoff();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CLEAR_FAST_REPAIR))
             {
                 ClearFastRepair();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CLEAR_FUEL))
             {
                 ClearFuel();
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_TYRE_PRESSURE) ||
@@ -307,7 +307,7 @@ namespace CrewChiefV4.Events
                 }
                 if (amount == 0)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderDidntUnderstand, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderDidntUnderstand, 0));
                     return;
                 }
                 else
@@ -322,31 +322,31 @@ namespace CrewChiefV4.Events
                         ChangeTire(PitCommandModeTypes.RF, amount);
                         ChangeTire(PitCommandModeTypes.LR, amount);
                         ChangeTire(PitCommandModeTypes.RR, amount);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                         return;
                     }
                     else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_FRONT_LEFT_TYRE_PRESSURE))
                     {
                         ChangeTire(PitCommandModeTypes.LF, amount);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                         return;
                     }
                     else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_FRONT_RIGHT_TYRE_PRESSURE))
                     {
                         ChangeTire(PitCommandModeTypes.RF, amount);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                         return;
                     }
                     else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_REAR_LEFT_TYRE_PRESSURE))
                     {
                         ChangeTire(PitCommandModeTypes.LR, amount);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                         return;
                     }
                     else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_REAR_RIGHT_TYRE_PRESSURE))
                     {
                         ChangeTire(PitCommandModeTypes.RR, amount);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                         return;
                     }
                 }
@@ -357,31 +357,31 @@ namespace CrewChiefV4.Events
                 ChangeTire(PitCommandModeTypes.RF, lastColdFRPressure);
                 ChangeTire(PitCommandModeTypes.LR, lastColdRLPressure);
                 ChangeTire(PitCommandModeTypes.RR, lastColdRRPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_FRONT_LEFT_TYRE))
             {
                 ChangeTire(PitCommandModeTypes.LF, lastColdFLPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_FRONT_RIGHT_TYRE))
             {
                 ChangeTire(PitCommandModeTypes.RF, lastColdFRPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_REAR_LEFT_TYRE))
             {
                 ChangeTire(PitCommandModeTypes.LR, lastColdRLPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_REAR_RIGHT_TYRE))
             {
                 ChangeTire(PitCommandModeTypes.RR, lastColdRRPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_LEFT_SIDE_TYRES))
@@ -389,7 +389,7 @@ namespace CrewChiefV4.Events
                 ClearTires();
                 ChangeTire(PitCommandModeTypes.LF, lastColdFLPressure);
                 ChangeTire(PitCommandModeTypes.LR, lastColdRLPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.PIT_STOP_CHANGE_RIGHT_SIDE_TYRES))
@@ -397,24 +397,24 @@ namespace CrewChiefV4.Events
                 ClearTires();
                 ChangeTire(PitCommandModeTypes.RF, lastColdFRPressure);
                 ChangeTire(PitCommandModeTypes.RR, lastColdRRPressure);
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderAcknowlegeOK, 0));
                 return;
             }
 
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.HOW_MANY_INCIDENT_POINTS))
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage("Incidents/incidents", MessageContents(folderYouHave, incidentsCount, folderincidents), 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage("Incidents/incidents", 0, messageFragments: MessageContents(folderYouHave, incidentsCount, folderincidents)));
                 return;
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHATS_THE_INCIDENT_LIMIT))
             {
                 if (hasLimitedIncidents)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("Incidents/limit", MessageContents(folderincidentlimit, maxIncidentCount), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("Incidents/limit", 0, messageFragments: MessageContents(folderincidentlimit, maxIncidentCount)));
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("Incidents/limit", MessageContents(folderUnlimited), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("Incidents/limit", 0, messageFragments: MessageContents(folderUnlimited)));
                 }
                 return;
             }
@@ -422,12 +422,12 @@ namespace CrewChiefV4.Events
             {
                 if(iRating != -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("license/irating", MessageContents(iRating), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("license/irating", 0, messageFragments: MessageContents(iRating)));
                     return;
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                     return;
                 }
             }
@@ -435,7 +435,7 @@ namespace CrewChiefV4.Events
             {
                 if (licenseLevel.Item2 == -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                     return;
                 }
                 if (licenseLevel.Item2 != -1)
@@ -473,7 +473,7 @@ namespace CrewChiefV4.Events
                         return;
                     }
                     messageFragments.AddRange(MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2));
-                    QueuedMessage licenceLevelMessage = new QueuedMessage("License/license", messageFragments, 0, null);
+                    QueuedMessage licenceLevelMessage = new QueuedMessage("License/license", 0, messageFragments: messageFragments);
                     audioPlayer.playDelayedImmediateMessage(licenceLevelMessage);
                 }
                 return;
@@ -482,7 +482,7 @@ namespace CrewChiefV4.Events
             {
                 if (strenghtOfField != -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("license/irating", MessageContents(strenghtOfField), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("license/irating", 0, messageFragments: MessageContents(strenghtOfField)));
                     return;
                 }
                 else

--- a/CrewChiefV4/Events/LapCounter.cs
+++ b/CrewChiefV4/Events/LapCounter.cs
@@ -183,25 +183,25 @@ namespace CrewChiefV4.Events
             if (currentConditions != null)
             {
                 Console.WriteLine("Pre-start message for track temp");
-                possibleMessages.Add(new QueuedMessage("trackTemp", MessageContents(ConditionsMonitor.folderTrackTempIs,
-                    convertTemp(currentConditions.TrackTemperature), getTempUnit()), 0, this));
+                possibleMessages.Add(new QueuedMessage("trackTemp", 0, messageFragments: MessageContents(ConditionsMonitor.folderTrackTempIs,
+                    convertTemp(currentConditions.TrackTemperature), getTempUnit()), abstractEvent: this, priority: 10));
                 Console.WriteLine("Pre-start message for air temp");
-                possibleMessages.Add(new QueuedMessage("air_temp", MessageContents(ConditionsMonitor.folderAirTempIs,
-                    convertTemp(currentConditions.AmbientTemperature), getTempUnit()), 0, this));
+                possibleMessages.Add(new QueuedMessage("air_temp", 0, messageFragments: MessageContents(ConditionsMonitor.folderAirTempIs,
+                    convertTemp(currentConditions.AmbientTemperature), getTempUnit()), abstractEvent: this, priority: 10));
             }
             if (currentGameState.PitData.HasMandatoryPitStop && CrewChief.gameDefinition.gameEnum != GameEnum.RF1 && CrewChief.gameDefinition.gameEnum != GameEnum.RF2_64BIT)
             {
                 if (currentGameState.SessionData.SessionHasFixedTime)
                 {
                     Console.WriteLine("Pre-start message for mandatory stop time");
-                    possibleMessages.Add(new QueuedMessage("pit_window_time", MessageContents(PitStops.folderMandatoryPitStopsPitWindowOpensAfter,
-                        TimeSpanWrapper.FromMinutes(currentGameState.PitData.PitWindowStart, Precision.MINUTES)), 0, this));
+                    possibleMessages.Add(new QueuedMessage("pit_window_time", 0, messageFragments: MessageContents(PitStops.folderMandatoryPitStopsPitWindowOpensAfter,
+                        TimeSpanWrapper.FromMinutes(currentGameState.PitData.PitWindowStart, Precision.MINUTES)), abstractEvent: this, priority: 10));
                 } 
                 else
                 {
                     Console.WriteLine("Pre-start message for mandatory stop lap");
-                    possibleMessages.Add(new QueuedMessage("pit_window_lap", MessageContents(PitStops.folderMandatoryPitStopsPitWindowOpensOnLap,
-                        currentGameState.PitData.PitWindowStart), 0, this));
+                    possibleMessages.Add(new QueuedMessage("pit_window_lap", 0, messageFragments: MessageContents(PitStops.folderMandatoryPitStopsPitWindowOpensOnLap,
+                        currentGameState.PitData.PitWindowStart), abstractEvent: this, priority: 10));
                 }
             }
             if (currentGameState.SessionData.ClassPosition == 1)
@@ -209,11 +209,13 @@ namespace CrewChiefV4.Events
                 Console.WriteLine("Pre-start message for pole");
                 if (SoundCache.availableSounds.Contains(Position.folderDriverPositionIntro))
                 {
-                    possibleMessages.Add(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro, Position.folderPole), 0, this));
+                    possibleMessages.Add(new QueuedMessage("position", 0,
+                        messageFragments: MessageContents(Position.folderDriverPositionIntro, Position.folderPole), abstractEvent: this, priority: 10));
                 }
                 else
                 {
-                    possibleMessages.Add(new QueuedMessage("position", MessageContents(Pause(200), Position.folderPole), 0, this));
+                    possibleMessages.Add(new QueuedMessage("position", 0, messageFragments: MessageContents(Pause(200), Position.folderPole),
+                        abstractEvent: this, priority: 10));
                 }
             }
             else
@@ -221,12 +223,13 @@ namespace CrewChiefV4.Events
                 Console.WriteLine("Pre-start message for P " + currentGameState.SessionData.ClassPosition);
                 if (SoundCache.availableSounds.Contains(Position.folderDriverPositionIntro))
                 {
-                    possibleMessages.Add(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro,
-                        Position.folderStub + currentGameState.SessionData.ClassPosition), 0, this));
+                    possibleMessages.Add(new QueuedMessage("position", 0, messageFragments: MessageContents(Position.folderDriverPositionIntro,
+                        Position.folderStub + currentGameState.SessionData.ClassPosition), abstractEvent: this, priority: 10));
                 }
                 else
                 {
-                    possibleMessages.Add(new QueuedMessage("position", MessageContents(Pause(200), Position.folderStub + currentGameState.SessionData.ClassPosition), 0, this));
+                    possibleMessages.Add(new QueuedMessage("position", 0, 
+                        messageFragments: MessageContents(Pause(200), Position.folderStub + currentGameState.SessionData.ClassPosition), abstractEvent: this, priority: 10));
                 }
             }
             if (currentGameState.SessionData.SessionNumberOfLaps > 0) {
@@ -237,13 +240,15 @@ namespace CrewChiefV4.Events
                 {
                     // anything less than 20000 metres worth of racing (e.g. 10 laps of Brands Indy) should have a 'make them count'
                     Console.WriteLine("Pre-start message for race laps + get on with it");
-                    possibleMessages.Add(new QueuedMessage("race_distance", MessageContents(currentGameState.SessionData.SessionNumberOfLaps, folderLapsMakeThemCount), 0, this));
+                    possibleMessages.Add(new QueuedMessage("race_distance", 0, 
+                        messageFragments: MessageContents(currentGameState.SessionData.SessionNumberOfLaps, folderLapsMakeThemCount), abstractEvent: this, priority: 10));
                 }
                 else
                 {
                     Console.WriteLine("Pre-start message for race laps");
                     // use the 'Laps' sound from Battery here
-                    possibleMessages.Add(new QueuedMessage("race_distance", MessageContents(currentGameState.SessionData.SessionNumberOfLaps, Battery.folderLaps), 0, this));
+                    possibleMessages.Add(new QueuedMessage("race_distance", 0,
+                        messageFragments: MessageContents(currentGameState.SessionData.SessionNumberOfLaps, Battery.folderLaps), abstractEvent: this, priority: 10));
                 }
             }
             else if (CrewChief.gameDefinition.gameEnum != GameEnum.RF1 && /* session time in gridwalk phase isn't usable in rf1 */
@@ -254,13 +259,14 @@ namespace CrewChiefV4.Events
                 if (currentGameState.SessionData.ClassPosition > 3 && minutes < 20 && minutes > 1)
                 {
                     Console.WriteLine("Pre-start message for race time " + minutes + " minutes + get on with it");
-                    possibleMessages.Add(new QueuedMessage("race_time", MessageContents(minutes, folderMinutesYouNeedToGetOnWithIt), 0, this));
+                    possibleMessages.Add(new QueuedMessage("race_time", 0, 
+                        messageFragments: MessageContents(minutes, folderMinutesYouNeedToGetOnWithIt), abstractEvent: this, priority: 10));
                 }
                 //dont play pre-start message for race time unless its more then 2 minuts
                 else
                 {
                     Console.WriteLine("Pre-start message for race time:" + minutes + " minutes");
-                    possibleMessages.Add(new QueuedMessage("race_time", MessageContents(minutes, Battery.folderMinutes), 0, this));
+                    possibleMessages.Add(new QueuedMessage("race_time", 0, messageFragments: MessageContents(minutes, Battery.folderMinutes), abstractEvent: this, priority: 10));
                 }
             }
             // now pick a random selection
@@ -275,7 +281,7 @@ namespace CrewChiefV4.Events
                     {
                         break;
                     }
-                    audioPlayer.playMessage(message, 10);
+                    audioPlayer.playMessage(message);
                 }
             }
         }
@@ -295,7 +301,7 @@ namespace CrewChiefV4.Events
                          currentGameState.SessionData.SessionPhase == SessionPhase.Gridwalk))
                     {
                         playedPreLightsRollingStartWarning = true;
-                        audioPlayer.playMessage(new QueuedMessage(FrozenOrderMonitor.folderRollingStartReminder, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(FrozenOrderMonitor.folderRollingStartReminder, 0, abstractEvent: this, priority: 10));
                     }
 
                     // when the lights change to green, give some info:
@@ -341,7 +347,7 @@ namespace CrewChiefV4.Events
                             // empty the queue and play 'get ready'
                             int purgedCount = audioPlayer.purgeQueues();
                             Console.WriteLine("Purging pre-lights messages, removed = " + purgedCount + " messages");
-                            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, abstractEvent: this, priority: 10));
                             playedGetReady = true;
                         }
                         else
@@ -421,7 +427,7 @@ namespace CrewChiefV4.Events
                         {
                             audioPlayer.purgeQueues();
                         }
-                        audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderGetReady, 5, abstractEvent: this, priority: 10));
                         playedGetReady = true;
                     }
                 }
@@ -439,7 +445,7 @@ namespace CrewChiefV4.Events
                     {
                         Console.WriteLine("Purged " + purgeCount + " outstanding messages at green light");
                     }
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderGreenGreenGreen, 0, this) { metadata = new SoundMetadata(SoundType.CRITICAL_MESSAGE, 15) });
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderGreenGreenGreen, 2, abstractEvent: this, type: SoundType.CRITICAL_MESSAGE, priority: 15));
                     audioPlayer.disablePearlsOfWisdom = false;
                 }
             }
@@ -464,15 +470,15 @@ namespace CrewChiefV4.Events
                     Console.WriteLine("1 lap remaining");
                     if (position == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 10, abstractEvent: this, priority: 10));
                     }
                     else if (position < 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderLastLapTopThree, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderLastLapTopThree, 10, abstractEvent: this, priority: 10));
                     }
                     else if (position > 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderLastLapUS : folderLastLapEU, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(GlobalBehaviourSettings.useAmericanTerms ? folderLastLapUS : folderLastLapEU, 10, abstractEvent: this, priority: 10));
                     }
                     else
                     {
@@ -484,11 +490,11 @@ namespace CrewChiefV4.Events
                     Console.WriteLine("2 laps remaining");
                     if (position == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftLeading, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftLeading, 10, abstractEvent: this, priority: 10));
                     }
                     else if (position < 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftTopThree, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeftTopThree, 10, abstractEvent: this, priority: 10));
                     }
                     else if (position >= currentGameState.SessionData.SessionStartClassPosition + 5 &&
                         currentGameState.SessionData.LapTimePrevious > currentGameState.TimingData.getPlayerBestLapTime())
@@ -497,12 +503,12 @@ namespace CrewChiefV4.Events
                         // might be invalid so perhaps they're really not being shit. At the moment.
                         if (CrewChief.gameDefinition.gameEnum != GameEnum.ASSETTO_32BIT && CrewChief.gameDefinition.gameEnum != GameEnum.ASSETTO_64BIT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 0, this), PearlsOfWisdom.PearlType.BAD, 0.5, 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 10, abstractEvent: this, priority: 10), PearlsOfWisdom.PearlType.BAD, 0.5);
                         }
                     }
                     else if (position >= 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, 0.5, 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLeft, 10, abstractEvent: this, priority: 10), PearlsOfWisdom.PearlType.NEUTRAL, 0.5);
                     }
                     else
                     {
@@ -517,7 +523,7 @@ namespace CrewChiefV4.Events
         {
             if (!playedManualStartPlayedGoGoGo)
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage(folderGreenGreenGreen, 0, this) { metadata = new SoundMetadata(SoundType.CRITICAL_MESSAGE, 15) });
+                audioPlayer.playMessageImmediately(new QueuedMessage(folderGreenGreenGreen, 3, abstractEvent: this, type: SoundType.CRITICAL_MESSAGE, priority: 15));
             }
             GameStateData.onManualFormationLap = false;
             // reset
@@ -534,7 +540,7 @@ namespace CrewChiefV4.Events
 
         private void playManualStartGetReady()
         {
-            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 0, this), 10);
+            audioPlayer.playMessage(new QueuedMessage(folderGetReady, 3, abstractEvent: this, priority: 10));
             playedManualStartGetReady = true;
         }
 
@@ -651,11 +657,12 @@ namespace CrewChiefV4.Events
             }
             if (opponentToLineUpBehind == null)
             {
-                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", messageContentsNoName, 0, this), 10);
+                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", 5, messageFragments: messageContentsNoName, abstractEvent: this, priority: 10));
             }
             else
             {
-                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", messageContentsWithName, messageContentsNoName, 0, this), 10);
+                audioPlayer.playMessage(new QueuedMessage("manual_start_intro", 5, messageFragments: messageContentsWithName,
+                    alternateMessageFragments: messageContentsNoName, abstractEvent: this, priority: 10));
             }
             playedManualStartInitialMessage = true;
         }
@@ -681,19 +688,21 @@ namespace CrewChiefV4.Events
                     {
                         if (gridSide == GridSide.LEFT)
                         {
-                            audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", MessageContents(folderManualStartInitialOutroWithDriverName1,
-                                    newOpponentToFollow, FrozenOrderMonitor.folderInTheLeftColumn), 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", 3, 
+                                messageFragments: MessageContents(folderManualStartInitialOutroWithDriverName1, newOpponentToFollow, FrozenOrderMonitor.folderInTheLeftColumn), 
+                                abstractEvent: this, priority: 10));
                         }
                         else
                         {
-                            audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", MessageContents(folderManualStartInitialOutroWithDriverName1,
-                                    newOpponentToFollow, FrozenOrderMonitor.folderInTheRightColumn), 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", 3, 
+                                messageFragments: MessageContents(folderManualStartInitialOutroWithDriverName1, newOpponentToFollow, FrozenOrderMonitor.folderInTheRightColumn),
+                                abstractEvent: this, priority: 10));
                         }
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", MessageContents(folderManualStartInitialOutroWithDriverName1,
-                                    newOpponentToFollow), 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage("new_car_to_follow", 3,
+                            messageFragments: MessageContents(folderManualStartInitialOutroWithDriverName1, newOpponentToFollow), abstractEvent: this, priority: 10));
                     }
                 }
             }
@@ -702,7 +711,7 @@ namespace CrewChiefV4.Events
                 if (!playedRejoinAtBackMessage)
                 {
                     playedRejoinAtBackMessage = true;
-                    audioPlayer.playMessage(new QueuedMessage("rejoin_at_back", MessageContents(folderManualStartRejoinAtBack), 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage("rejoin_at_back", 5, messageFragments: MessageContents(folderManualStartRejoinAtBack), abstractEvent: this, priority: 10));
                 }
                 setOpponentToFollowAndStartPosition(currentGameState, true, false);
             }
@@ -717,9 +726,9 @@ namespace CrewChiefV4.Events
                     validationData.Add("PlayerPosition", currentGameState.SessionData.OverallPosition);
                     validationData.Add("OpponentToFollowName", this.manualStartOpponentToFollow);
 
-                    audioPlayer.playMessage(new QueuedMessage("give_position_back",
-                        MessageContents(folderGivePositionBack, folderManualStartInitialOutroWithDriverName1, getOpponent(currentGameState, manualStartOpponentToFollow)),
-                        MessageContents(folderGivePositionBack), 5, this, validationData), 10);                    
+                    audioPlayer.playMessage(new QueuedMessage("give_position_back", 10, secondsDelay: 5, validationData: validationData,
+                        messageFragments: MessageContents(folderGivePositionBack, folderManualStartInitialOutroWithDriverName1, getOpponent(currentGameState, manualStartOpponentToFollow)),
+                        alternateMessageFragments: MessageContents(folderGivePositionBack), abstractEvent: this, priority: 10));                    
                 }
             }
         }
@@ -754,7 +763,7 @@ namespace CrewChiefV4.Events
                     if (poleSitter.Speed - leaderSpeedAtAccelerationCheckStart > 5)
                     {
                         Console.WriteLine("Looks like the leader has 'gone'");
-                        audioPlayer.playMessage(new QueuedMessage(folderManualStartLeaderHasGone, 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderManualStartLeaderHasGone, 2, abstractEvent: this, priority: 10));
                         leaderHasGone = true;
                     }
                 }
@@ -801,11 +810,12 @@ namespace CrewChiefV4.Events
                 }
                 if (opponentToLineUpBehind == null)
                 {
-                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", messageContentsNoName, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", 10, messageFragments: messageContentsNoName, abstractEvent: this, priority: 10));
                 }
                 else
                 {
-                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", messageContentsWithName, messageContentsNoName, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage("manual_start_double_file_reminder", 10, messageFragments: messageContentsWithName, 
+                        alternateMessageFragments: messageContentsNoName, abstractEvent: this, priority: 10));
                 }
             }
         }
@@ -861,7 +871,7 @@ namespace CrewChiefV4.Events
                         if (poleSitter != null && !playedManualStartLeaderHasCrossedLine && poleSitter.CompletedLaps == 1)
                         {
                             playedManualStartLeaderHasCrossedLine = true;
-                            audioPlayer.playMessageImmediately(new QueuedMessage(folderLeaderHasCrossedStartLine, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage(folderLeaderHasCrossedStartLine, 2, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                     }
                 }

--- a/CrewChiefV4/Events/LapTimes.cs
+++ b/CrewChiefV4/Events/LapTimes.cs
@@ -443,21 +443,23 @@ namespace CrewChiefV4.Events
                             if (isHotLappingOrLonePractice && reportAllLaptimesInHotlapMode)
                             {
                                 // If requested, always play the laptime in hotlap/lone practice mode
-                                audioPlayer.playMessage(new QueuedMessage("laptime",
-                                        MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage("laptime", 0,
+                                        messageFragments: MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)),
+                                        abstractEvent: this, priority: 10));
                                 playedLapTime = true;
                             }
                             else if (((currentGameState.SessionData.SessionType == SessionType.Qualify || currentGameState.SessionData.SessionType == SessionType.Practice) && frequencyOfPlayerQualAndPracLapTimeReports > Utilities.random.NextDouble() * 10)
                                 || (currentGameState.SessionData.SessionType == SessionType.Race && frequencyOfPlayerRaceLapTimeReports > Utilities.random.NextDouble() * 10))
                             {
                                 // usually play it in practice / qual mode, occasionally play it in race mode
-                                QueuedMessage gapFillerLapTime = new QueuedMessage("laptime",
-                                    MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, this);
+                                QueuedMessage gapFillerLapTime = new QueuedMessage("laptime", 0,
+                                    messageFragments: MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 
+                                    abstractEvent: this, priority: 0);
                                 if (currentGameState.SessionData.SessionType == SessionType.Race)
                                 {
                                     gapFillerLapTime.maxPermittedQueueLengthForMessage = maxQueueLengthForRaceLapTimeReports;
                                 }
-                                audioPlayer.playMessage(gapFillerLapTime, 0);
+                                audioPlayer.playMessage(gapFillerLapTime);
                                 playedLapTime = true;
                             }
 
@@ -472,19 +474,19 @@ namespace CrewChiefV4.Events
                                         (isHotLappingOrLonePractice ? lastLapRating == LastLapRating.BEST_OVERALL : lastLapRating == LastLapRating.BEST_IN_CLASS 
                                             || deltaPlayerLastToSessionBestInClass <= TimeSpan.Zero))
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), 3);
+                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, abstractEvent: this, priority: 3));
                                     }
                                     else if (deltaPlayerLastToSessionBestInClass > TimeSpan.Zero  // Guard against first lap time set.
                                         && deltaPlayerLastToSessionBestInClass < TimeSpan.FromMilliseconds(50))
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage((isHotLappingOrLonePractice ? folderSelfLessThanATenthOffThePace : folderLessThanATenthOffThePace), 0, this), 3);
+                                        audioPlayer.playMessage(new QueuedMessage((isHotLappingOrLonePractice ? folderSelfLessThanATenthOffThePace : folderLessThanATenthOffThePace), 0, abstractEvent: this, priority: 3));
                                     }
                                     else if (deltaPlayerLastToSessionBestInClass > TimeSpan.Zero  // Guard against first lap time set.
                                         && deltaPlayerLastToSessionBestInClass < TimeSpan.MaxValue)
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
-                                            MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS),
-                                            isHotLappingOrLonePractice ? folderSelfGapOutroOffPace : folderGapOutroOffPace), 0, this), 3);
+                                        audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap", 0,
+                                            messageFragments: MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS),
+                                            isHotLappingOrLonePractice ? folderSelfGapOutroOffPace : folderGapOutroOffPace), abstractEvent: this, priority: 3));
                                     }
                                     if (!GlobalBehaviourSettings.useOvalLogic &&
                                         practiceAndQualSectorReportsLapEnd && frequencyOfPracticeAndQualSectorDeltaReports > Utilities.random.NextDouble() * 10)
@@ -493,7 +495,7 @@ namespace CrewChiefV4.Events
                                             currentGameState.SessionData.LastSector2Time, lapAndSectorsComparisonData[2], currentGameState.SessionData.LastSector3Time, lapAndSectorsComparisonData[3], true, isHotLappingOrLonePractice /*selfPace*/);
                                         if (sectorMessageFragments.Count > 0)
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage("sectorsHotLap", sectorMessageFragments, 0, this), 3);
+                                            audioPlayer.playMessage(new QueuedMessage("sectorsHotLap", 0, messageFragments: sectorMessageFragments, abstractEvent: this, priority: 3));
                                             sectorsReportedForLap = true;
                                         }
                                     }
@@ -507,17 +509,17 @@ namespace CrewChiefV4.Events
                                         newGapToSecond = true;
                                         if (currentGameState.SessionData.SessionType == SessionType.Qualify)
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage(Position.folderPole, 0, this), 10);
+                                            audioPlayer.playMessage(new QueuedMessage(Position.folderPole, 0, abstractEvent: this, priority: 10));
                                         }
                                         else if (currentGameState.SessionData.SessionType == SessionType.Practice)
                                         {
                                             if (SoundCache.availableSounds.Contains(Position.folderDriverPositionIntro))
                                             {
-                                                audioPlayer.playMessage(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro, Position.folderStub + 1), 0, this), 5);
+                                                audioPlayer.playMessage(new QueuedMessage("position", 0, messageFragments: MessageContents(Position.folderDriverPositionIntro, Position.folderStub + 1), abstractEvent: this, priority: 5));
                                             }
                                             else
                                             {
-                                                audioPlayer.playMessage(new QueuedMessage(Position.folderStub + 1, 0, this), 5);
+                                                audioPlayer.playMessage(new QueuedMessage(Position.folderStub + 1, 0, abstractEvent: this, priority: 3));
                                             }
                                         }
                                     }
@@ -539,8 +541,9 @@ namespace CrewChiefV4.Events
                                             (gapBehind.Seconds > 0 || gapBehind.Milliseconds > 50))
                                         {
                                             // delay this a bit...
-                                            audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
-                                                MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), Utilities.random.Next(0, 8), this), 5);
+                                            int delay = Utilities.random.Next(0, 8);
+                                            audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap", delay + 6,
+                                                messageFragments: MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), abstractEvent: this, priority: 5));
                                         }
                                     }
                                 }
@@ -550,7 +553,7 @@ namespace CrewChiefV4.Events
                                         (lastLapRating == LastLapRating.PERSONAL_BEST_STILL_SLOW || lastLapRating == LastLapRating.PERSONAL_BEST_CLOSE_TO_CLASS_LEADER ||
                                          lastLapRating == LastLapRating.PERSONAL_BEST_CLOSE_TO_OVERALL_LEADER))
                                     {
-                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), 7);
+                                        audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, abstractEvent: this, priority: 7));
                                     }
                                     // don't read this message if the rounded time gap is 0.0 seconds or it's more than 59 seconds
                                     // only play qual / prac deltas for Raceroom as the PCars data is inaccurate for sessions joined part way through
@@ -563,8 +566,8 @@ namespace CrewChiefV4.Events
                                         deltaPlayerLastToSessionBestInClass.Seconds < 60)
                                     {
                                         // delay this a bit...
-                                        audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap",
-                                            MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS), folderGapOutroOffPace), Utilities.random.Next(0, 8), this), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("lapTimeNotRaceGap", 0,
+                                            messageFragments: MessageContents(folderGapIntro, new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS), folderGapOutroOffPace), abstractEvent: this, priority: 5));
                                     }
                                     if (!GlobalBehaviourSettings.useOvalLogic && 
                                         practiceAndQualSectorReportsLapEnd && frequencyOfPracticeAndQualSectorDeltaReports > Utilities.random.NextDouble() * 10)
@@ -573,7 +576,7 @@ namespace CrewChiefV4.Events
                                             currentGameState.SessionData.LastSector2Time, lapAndSectorsComparisonData[2], currentGameState.SessionData.LastSector3Time, lapAndSectorsComparisonData[3], true, false /*selfPace*/);
                                         if (sectorMessageFragments.Count > 0)
                                         {
-                                            audioPlayer.playMessage(new QueuedMessage("sectorDeltas", sectorMessageFragments, 0, this), 5);
+                                            audioPlayer.playMessage(new QueuedMessage("sectorDeltas", 0, messageFragments: sectorMessageFragments, abstractEvent: this, priority: 5));
                                             sectorsReportedForLap = true;
                                         }
                                     }
@@ -589,32 +592,32 @@ namespace CrewChiefV4.Events
                                     {
                                         case LastLapRating.BEST_OVERALL:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 3);
+                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRace, 0, abstractEvent: this, priority: 3), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
                                             break;
                                         case LastLapRating.BEST_IN_CLASS:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRaceForClass, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 3);
+                                            audioPlayer.playMessage(new QueuedMessage(folderBestLapInRaceForClass, 0, abstractEvent: this, priority: 3), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
                                             break;
                                         case LastLapRating.SETTING_CURRENT_PACE:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderSettingCurrentRacePace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 3);
+                                            audioPlayer.playMessage(new QueuedMessage(folderSettingCurrentRacePace, 0, abstractEvent: this, priority: 3), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
                                             break;
                                         case LastLapRating.CLOSE_TO_CURRENT_PACE:
                                             // don't keep playing this one
                                             if (Utilities.random.NextDouble() < 0.5)
                                             {
                                                 playedLapMessage = true;
-                                                audioPlayer.playMessage(new QueuedMessage(folderMatchingCurrentRacePace, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 0);
+                                                audioPlayer.playMessage(new QueuedMessage(folderMatchingCurrentRacePace, 0, abstractEvent: this, priority: 0), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
                                             }
                                             break;
                                         case LastLapRating.PERSONAL_BEST_CLOSE_TO_OVERALL_LEADER:
                                         case LastLapRating.PERSONAL_BEST_CLOSE_TO_CLASS_LEADER:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, this), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood, 0);
+                                            audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, abstractEvent: this, priority: 0), PearlsOfWisdom.PearlType.GOOD, pearlLikelihood);
                                             break;
                                         case LastLapRating.PERSONAL_BEST_STILL_SLOW:
                                             playedLapMessage = true;
-                                            audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood, 0);
+                                            audioPlayer.playMessage(new QueuedMessage(folderPersonalBest, 0, abstractEvent: this, priority: 0), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood);
                                             break;
                                         case LastLapRating.CLOSE_TO_OVERALL_LEADER:
                                         case LastLapRating.CLOSE_TO_CLASS_LEADER:
@@ -622,7 +625,7 @@ namespace CrewChiefV4.Events
                                             if (Utilities.random.NextDouble() < 0.2)
                                             {
                                                 playedLapMessage = true;
-                                                audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, this), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood, 0);
+                                                audioPlayer.playMessage(new QueuedMessage(folderGoodLap, 0, abstractEvent: this, priority: 0), PearlsOfWisdom.PearlType.NEUTRAL, pearlLikelihood);
                                             }
                                             break;
                                         default:
@@ -650,9 +653,9 @@ namespace CrewChiefV4.Events
                                             currentGameState.SessionData.LastSector2Time, lapAndSectorsComparisonData[2], currentGameState.SessionData.LastSector3Time, lapAndSectorsComparisonData[3], false, false /*selfPace*/);
                                     if (sectorMessageFragments.Count > 0)
                                     {
-                                        QueuedMessage message = new QueuedMessage("sectorDeltas", sectorMessageFragments, 0, this);
+                                        QueuedMessage message = new QueuedMessage("sectorDeltas", 0, messageFragments: sectorMessageFragments, abstractEvent: this, priority: 0);
                                         message.maxPermittedQueueLengthForMessage = maxQueueLengthForRaceSectorDeltaReports;
-                                        audioPlayer.playMessage(message, 0);
+                                        audioPlayer.playMessage(message);
                                         sectorsReportedForLap = true;
                                     }
                                 }
@@ -663,16 +666,17 @@ namespace CrewChiefV4.Events
                                 if (playConsistencyMessage && currentGameState.SessionData.CompletedLaps >= lastConsistencyUpdate + lapTimesWindowSize &&
                                     lapTimesWindow.Count >= lapTimesWindowSize)
                                 {
+                                    int delay = Utilities.random.Next(0, 8);
                                     ConsistencyResult consistency = checkAgainstPreviousLaps();
                                     if (consistency == ConsistencyResult.CONSISTENT)
                                     {
                                         lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
-                                        audioPlayer.playMessage(new QueuedMessage(folderConsistentTimes, Utilities.random.Next(0, 8), this), 0);
+                                        audioPlayer.playMessage(new QueuedMessage(folderConsistentTimes, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 0));
                                     }
                                     else if (consistency == ConsistencyResult.IMPROVING)
                                     {
                                         lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
-                                        audioPlayer.playMessage(new QueuedMessage(folderImprovingTimes, Utilities.random.Next(0, 8), this), 5);
+                                        audioPlayer.playMessage(new QueuedMessage(folderImprovingTimes, delay + 10, secondsDelay: delay, abstractEvent: this, priority: 5));
                                     }
                                     else if (consistency == ConsistencyResult.WORSENING)
                                     {
@@ -687,7 +691,8 @@ namespace CrewChiefV4.Events
                                             // only complain about worsening laptimes if we've not overtaken anyone on this lap
                                             lastConsistencyUpdate = currentGameState.SessionData.CompletedLaps;
 
-                                            audioPlayer.playMessage(new QueuedMessage(folderWorseningTimes, Utilities.random.Next(0, 8), this, new Dictionary<String, Object>()), 3);
+                                            audioPlayer.playMessage(new QueuedMessage(folderWorseningTimes, delay + 10, secondsDelay: delay, abstractEvent: this,
+                                                validationData: new Dictionary<String, Object>(), priority: 3));
                                         }
                                     }
                                 }
@@ -747,7 +752,8 @@ namespace CrewChiefV4.Events
                         if (!GlobalBehaviourSettings.useOvalLogic && 
                             messageFragments.Count() > 0)
                         {
-                            audioPlayer.playMessage(new QueuedMessage("singleSectorDelta", messageFragments, Utilities.random.Next(2, 4), this), 5);
+                            int delay = Utilities.random.Next(2, 4);
+                            audioPlayer.playMessage(new QueuedMessage("singleSectorDelta", delay + 10, secondsDelay: delay, messageFragments: messageFragments, abstractEvent: this, priority: 5));
                         }
                     }
                 }
@@ -968,12 +974,12 @@ namespace CrewChiefV4.Events
                 if (currentGameState != null && 
                     currentGameState.SessionData.LastSector1Time > -1 && currentGameState.SessionData.LastSector2Time > -1 && currentGameState.SessionData.LastSector3Time > -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sector1Time",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector1Time, Precision.AUTO_LAPTIMES)), 0, null));
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sector2Time",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector2Time, Precision.AUTO_LAPTIMES)), 0, null));
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sector3Time",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector3Time, Precision.AUTO_LAPTIMES)), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sector1Time", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector1Time, Precision.AUTO_LAPTIMES))));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sector2Time", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector2Time, Precision.AUTO_LAPTIMES))));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sector3Time", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector3Time, Precision.AUTO_LAPTIMES))));
                 }
                 else
                 {
@@ -985,18 +991,18 @@ namespace CrewChiefV4.Events
             {
                 if (currentGameState != null && currentGameState.SessionData.SectorNumber == 1 && currentGameState.SessionData.LastSector3Time > -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sector3Time",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector3Time, Precision.AUTO_LAPTIMES)), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sector3Time", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector3Time, Precision.AUTO_LAPTIMES))));
                 }
                 else if (currentGameState != null && currentGameState.SessionData.SectorNumber == 2 && currentGameState.SessionData.LastSector1Time > -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sector1Time",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector1Time, Precision.AUTO_LAPTIMES)), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sector1Time", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector1Time, Precision.AUTO_LAPTIMES))));
                 }
                 else if (currentGameState != null && currentGameState.SessionData.SectorNumber == 3 && currentGameState.SessionData.LastSector2Time > -1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sector2Time",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector2Time, Precision.AUTO_LAPTIMES)), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sector2Time", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.LastSector2Time, Precision.AUTO_LAPTIMES))));
                 }
                 else
                 {
@@ -1013,39 +1019,39 @@ namespace CrewChiefV4.Events
                     if (bestLap > 0)
                     {
                         gotData = true;
-                        audioPlayer.playMessageImmediately(new QueuedMessage("bestLapTime",
-                            MessageContents(TimeSpanWrapper.FromSeconds(bestLap, Precision.AUTO_LAPTIMES)), 0, this));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("bestLapTime", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(bestLap, Precision.AUTO_LAPTIMES))));
                     }
                 }
                 if (!gotData)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHATS_THE_FASTEST_LAP_TIME))
             {
                 if (currentGameState.SessionData.PlayerClassSessionBestLapTime > 0)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("sessionFastestLaptime",
-                        MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.PlayerClassSessionBestLapTime, Precision.AUTO_LAPTIMES)), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("sessionFastestLaptime", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(currentGameState.SessionData.PlayerClassSessionBestLapTime, Precision.AUTO_LAPTIMES))));
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHAT_WAS_MY_LAST_LAP_TIME))
             {
                 if (CrewChief.currentGameState != null && CrewChief.currentGameState.SessionData.LapTimePrevious > 0)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("laptime",
-                        MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(
-                        CrewChief.currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("laptime", 0,
+                        messageFragments: MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(
+                        CrewChief.currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES))));
                     
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.HOWS_MY_PACE))
@@ -1144,7 +1150,7 @@ namespace CrewChiefV4.Events
                                     }
                                     if (messages.Count > 0)
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments: messages));
                                     }
                                     break;
                                 case LastLapRating.MEH:
@@ -1152,7 +1158,7 @@ namespace CrewChiefV4.Events
                                     {
                                         messages.Add(MessageFragment.Text(timeToFindFolder));
                                     }
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments: messages));
                                     break;
                                 case LastLapRating.BAD:
                                     messages.Add(MessageFragment.Text(folderPaceBad));
@@ -1160,10 +1166,10 @@ namespace CrewChiefV4.Events
                                     {
                                         messages.Add(MessageFragment.Text(timeToFindFolder));
                                     }
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments: messages));
                                     break;
                                 default:
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                                     break;
                             }
                         }
@@ -1172,9 +1178,9 @@ namespace CrewChiefV4.Events
                             // Fors self pace case, announce last lap time.
                             if (currentGameState.SessionData.LapTimePrevious > 0)
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage("laptime",
-                                    MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(
-                                    currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, null));
+                                audioPlayer.playMessageImmediately(new QueuedMessage("laptime", 0, 
+                                    messageFragments: MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(
+                                    currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES))));
                             }
 
                             switch (lastLapSelfRating)
@@ -1193,7 +1199,7 @@ namespace CrewChiefV4.Events
                                     }
                                     if (messages.Count > 0)
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments:  messages));
                                     }
                                     break;
                                 case LastLapRating.BAD:
@@ -1202,17 +1208,17 @@ namespace CrewChiefV4.Events
                                     {
                                         messages.Add(MessageFragment.Text(timeToFindFolder));
                                     }
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments:  messages));
                                     break;
                                 case LastLapRating.MEH:
                                     if (timeToFindFolder != null)
                                     {
                                         messages.Add(MessageFragment.Text(timeToFindFolder));
                                     }
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments: messages));
                                     break;
                                 default:
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                                     break;
                             }
                         }
@@ -1227,12 +1233,12 @@ namespace CrewChiefV4.Events
                             currentGameState.SessionData.LastSector2Time, bestComparisonLapData[2], currentGameState.SessionData.LastSector3Time, bestComparisonLapData[3], false, selfPace);
                         if (sectorDeltaMessages.Count > 0)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("sectorDeltas", sectorDeltaMessages, 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("sectorDeltas", 0, messageFragments:  sectorDeltaMessages));
                         }
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                     }
                 }
             }
@@ -1246,18 +1252,18 @@ namespace CrewChiefV4.Events
                         {
                             if (sessionType == SessionType.Qualify && currentPosition == 1)
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage(Position.folderPole, 0, null));
+                                audioPlayer.playMessageImmediately(new QueuedMessage(Position.folderPole, 0));
                             }
                             else
                             {
-                                audioPlayer.playMessageImmediately(new QueuedMessage(folderQuickestOverall, 0, null));
+                                audioPlayer.playMessageImmediately(new QueuedMessage(folderQuickestOverall, 0));
                             }
                             TimeSpan gapBehind = deltaPlayerLastToSessionBestInClass.Negate();
                             if (gapBehind.Seconds > 0 || gapBehind.Milliseconds > 50)
                             {
                                 // delay this a bit...
-                                audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeNotRaceGap",
-                                    MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), 0, this));
+                                audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeNotRaceGap", 0,
+                                    messageFragments: MessageContents(folderGapIntro, new TimeSpanWrapper(gapBehind, Precision.AUTO_GAPS), folderQuickerThanSecondPlace), abstractEvent: this));
                             }
                         }
                         else if (deltaPlayerLastToSessionBestInClass.Seconds == 0 && deltaPlayerLastToSessionBestInClass.Milliseconds < 50)
@@ -1267,7 +1273,7 @@ namespace CrewChiefV4.Events
                                 // should always trigger
                                 if (SoundCache.availableSounds.Contains(Position.folderDriverPositionIntro))
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro, Position.folderStub + currentPosition), 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("position", 0, messageFragments: MessageContents(Position.folderDriverPositionIntro, Position.folderStub + currentPosition)));
                                 }
                                 else
                                 {
@@ -1283,15 +1289,15 @@ namespace CrewChiefV4.Events
                                 // should always trigger
                                 if (SoundCache.availableSounds.Contains(Position.folderDriverPositionIntro))
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("position", MessageContents(Position.folderDriverPositionIntro, Position.folderStub + currentPosition), 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("position", 0, messageFragments: MessageContents(Position.folderDriverPositionIntro, Position.folderStub + currentPosition)));
                                 }
                                 else
                                 {
                                     audioPlayer.playMessageImmediately(new QueuedMessage(Position.folderStub + currentPosition, 0, null));
                                 }
                             }
-                            audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeNotRaceGap",
-                                MessageContents(new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS), folderGapOutroOffPace), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeNotRaceGap", 0,
+                                messageFragments: MessageContents(new TimeSpanWrapper(deltaPlayerLastToSessionBestInClass, Precision.AUTO_GAPS), folderGapOutroOffPace)));
                         }
                     }
                     else
@@ -1299,24 +1305,24 @@ namespace CrewChiefV4.Events
                         // Fors self pace case, announce last lap time.
                         if (currentGameState.SessionData.LapTimePrevious > 0)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("laptime",
-                                MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(
-                                currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES)), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("laptime", 0,
+                                messageFragments: MessageContents(folderLapTimeIntro, TimeSpanWrapper.FromSeconds(
+                                currentGameState.SessionData.LapTimePrevious, Precision.AUTO_LAPTIMES))));
 
                             // We also neeed to announce how good it is.
                             List<MessageFragment> messages = new List<MessageFragment>();
                             switch (lastLapSelfRating)
                             {
                                 case LastLapRating.PERSONAL_BEST:
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderPersonalBest, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderPersonalBest, 0));
                                     break;
                                 case LastLapRating.CLOSE_TO_PERSONAL_BEST:
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderPaceOK, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderPaceOK, 0));
                                     break;
                                 case LastLapRating.MEH:
                                 case LastLapRating.BAD:
                                     messages.Add(MessageFragment.Text(folderPaceBad));
-                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", messages, 0, null));
+                                    audioPlayer.playMessageImmediately(new QueuedMessage("lapTimeRacePaceReport", 0, messageFragments: messages));
                                     break;
                                 default:
                                     break;
@@ -1342,7 +1348,7 @@ namespace CrewChiefV4.Events
                             currentGameState.SessionData.LastSector2Time, bestComparisonLapData[2], currentGameState.SessionData.LastSector3Time, bestComparisonLapData[3], true, selfPace);
                         if (sectorDeltaMessages.Count > 0)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("sectorDeltas", sectorDeltaMessages, 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("sectorDeltas", 0, messageFragments: sectorDeltaMessages));
                         }
                     }
                     catch (Exception e)
@@ -1352,7 +1358,7 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 }
             }
         }

--- a/CrewChiefV4/Events/MulticlassWarnings.cs
+++ b/CrewChiefV4/Events/MulticlassWarnings.cs
@@ -283,18 +283,19 @@ namespace CrewChiefV4.Events
                                     String classWithoutRunnersSuffix = folderClassStub + classNameToRead;
                                     if (SoundCache.availableSounds.Contains(classWithRunnersSuffix))
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("being_caught_by_known_car_class_runners",
-                                            MessageContents(folderYouAreBeingCaughtByThe, classWithRunnersSuffix), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("being_caught_by_known_car_class_runners", 5,
+                                            messageFragments: MessageContents(folderYouAreBeingCaughtByThe, classWithRunnersSuffix), abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("being_caught_by_known_car_class_runners",
-                                            MessageContents(folderYouAreBeingCaughtByThe, classWithoutRunnersSuffix, folderRunners), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("being_caught_by_known_car_class_runners", 5,
+                                            messageFragments: MessageContents(folderYouAreBeingCaughtByThe, classWithoutRunnersSuffix, folderRunners), abstractEvent: this,
+                                            type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderYouAreBeingCaughtByFasterCars, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderYouAreBeingCaughtByFasterCars, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                             }
                             else if (otherClassWarningData.numFasterCars > 1)
@@ -305,20 +306,20 @@ namespace CrewChiefV4.Events
                                 {
                                     if (otherClassWarningData.fasterCarsRacingForPosition)
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsFightingBehindIncludingClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsFightingBehindIncludingClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsBehindIncludingClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsBehindIncludingClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race && otherClassWarningData.fasterCarsRacingForPosition)
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsBehindFighting, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsBehindFighting, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsBehind, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarsBehind, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 // don't bother with 'no blue flag' warning here - this only really makes sense if all the 
                                 // cars in the group are racing the player for position. Do we need to fix this in the OtherCarClassWarningData data?
@@ -331,20 +332,20 @@ namespace CrewChiefV4.Events
                                 {
                                     if (otherClassWarningData.fasterCarIsRacingPlayerForPosition)
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehindRacingPlayerForPositionIsClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehindRacingPlayerForPositionIsClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehindIsClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehindIsClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race && otherClassWarningData.fasterCarIsRacingPlayerForPosition)
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehindRacingPlayerForPosition, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehindRacingPlayerForPosition, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 else
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehind, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderFasterCarBehind, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                             }
                             if (otherClassWarningData.numSlowerCars > 1)
@@ -365,38 +366,39 @@ namespace CrewChiefV4.Events
                                         String classWithoutRunnersSuffix = folderClassStub + classNameToRead;
                                         if (SoundCache.availableSounds.Contains(classWithRunnersSuffix))
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("catching_known_car_class_runners",
-                                                MessageContents(folderYouAreCatchingThe, classWithRunnersSuffix), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("catching_known_car_class_runners", 5,
+                                               messageFragments: MessageContents(folderYouAreCatchingThe, classWithRunnersSuffix), abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("catching_known_car_class_runners",
-                                                MessageContents(folderYouAreCatchingThe, classWithoutRunnersSuffix, folderRunners), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("catching_known_car_class_runners", 5,
+                                               messageFragments: MessageContents(folderYouAreCatchingThe, classWithoutRunnersSuffix, folderRunners), abstractEvent: this,
+                                               type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                         }                                        
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYouAreCatchingSlowerCars, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYouAreCatchingSlowerCars, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race && otherClassWarningData.slowerCarsIncludeClassLeader)
                                 {
                                     if (otherClassWarningData.slowerCarsRacingForPosition)
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsFightingAheadIncludingClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsFightingAheadIncludingClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsAheadIncludingClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsAheadIncludingClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race && otherClassWarningData.slowerCarsRacingForPosition)
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsAheadFighting, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsAheadFighting, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race || !disableSlowerCarWarningsInPracAndQual)
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsAhead, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarsAhead, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 caughtSlowerClassInThisSession = true;
                                 // don't bother with 'no blue flag' warning here - this only really makes sense if all the 
@@ -410,20 +412,20 @@ namespace CrewChiefV4.Events
                                 {
                                     if (otherClassWarningData.slowerCarIsRacingPlayerForPosition)
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAheadRacingPlayerForPositionIsClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAheadRacingPlayerForPositionIsClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAheadClassLeader, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                        audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAheadClassLeader, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                     }
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race && otherClassWarningData.slowerCarIsRacingPlayerForPosition)
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAheadRacingPlayerForPosition, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAheadRacingPlayerForPosition, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 else if (currentGameState.SessionData.SessionType == SessionType.Race || !disableSlowerCarWarningsInPracAndQual)
                                 {
-                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAhead, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                                    audioPlayer.playMessageImmediately(new QueuedMessage(folderSlowerCarAhead, 5, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                                 }
                                 caughtSlowerClassInThisSession = true;
                             }

--- a/CrewChiefV4/Events/Opponents.cs
+++ b/CrewChiefV4/Events/Opponents.cs
@@ -239,8 +239,9 @@ namespace CrewChiefV4.Events
                             Object opponentIdentifier = getOpponentIdentifierForTyreChange(opponentData, currentGameState.SessionData.ClassPosition);
                             if (opponentIdentifier != null)
                             {
-                                audioPlayer.playMessage(new QueuedMessage("opponent_tyre_change_" + opponentIdentifier.ToString(), MessageContents(opponentIdentifier,
-                                    folderIsNowOn, TyreMonitor.getFolderForTyreType(opponentData.CurrentTyres)), 0, this), 5);
+                                audioPlayer.playMessage(new QueuedMessage("opponent_tyre_change_" + opponentIdentifier.ToString(), 20,
+                                    messageFragments: MessageContents(opponentIdentifier, folderIsNowOn, TyreMonitor.getFolderForTyreType(opponentData.CurrentTyres)),
+                                    abstractEvent: this, priority: 5));
                             }
                         }
 
@@ -270,8 +271,9 @@ namespace CrewChiefV4.Events
                                 if ((currentGameState.SessionData.SessionType == SessionType.Race && frequencyOfOpponentRaceLapTimes > 0) ||
                                     (currentGameState.SessionData.SessionType != SessionType.Race && frequencyOfOpponentPracticeAndQualLapTimes > 0))
                                 {
-                                    audioPlayer.playMessage(new QueuedMessage("new_fastest_lap", MessageContents(folderNewFastestLapFor, opponentData,
-                                                TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 3);
+                                    audioPlayer.playMessage(new QueuedMessage("new_fastest_lap", 5,
+                                        messageFragments: MessageContents(folderNewFastestLapFor, opponentData, 
+                                        TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), abstractEvent: this, priority: 3));
                                 }
                             }
                             else if ((currentGameState.SessionData.SessionType == SessionType.Race &&
@@ -286,24 +288,27 @@ namespace CrewChiefV4.Events
                                 {
                                     // he's leading, and has recorded 3 or more laps, and this one's his fastest
                                     Console.WriteLine("Leader fast lap - this lap time = " + opponentData.LastLapTime + " session best = " + currentFastestLap);
-                                    audioPlayer.playMessage(new QueuedMessage("leader_good_laptime", MessageContents(folderLeaderHasJustDoneA,
-                                            TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 3);
+                                    audioPlayer.playMessage(new QueuedMessage("leader_good_laptime", 5,
+                                         messageFragments: MessageContents(folderLeaderHasJustDoneA, TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)),
+                                        abstractEvent: this, priority: 3));
                                 }
                                 else if (currentGameState.SessionData.ClassPosition > 1 && opponentData.ClassPosition == currentGameState.SessionData.ClassPosition - 1 &&
                                     (currentGameState.SessionData.SessionType == SessionType.Race || Utilities.random.Next(10) < frequencyOfOpponentPracticeAndQualLapTimes))
                                 {
                                     // he's ahead of us, and has recorded 3 or more laps, and this one's his fastest
                                     Console.WriteLine("Car ahead fast lap - this lap time = " + opponentData.LastLapTime + " session best = " + currentFastestLap);
-                                    audioPlayer.playMessage(new QueuedMessage("car_ahead_good_laptime", MessageContents(folderTheCarAheadHasJustDoneA,
-                                           TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 0);
+                                    audioPlayer.playMessage(new QueuedMessage("car_ahead_good_laptime", 5,
+                                        messageFragments: MessageContents(folderTheCarAheadHasJustDoneA, TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)),
+                                        abstractEvent: this, priority: 0));
                                 }
                                 else if (!currentGameState.isLast() && opponentData.ClassPosition == currentGameState.SessionData.ClassPosition + 1 &&
                                     (currentGameState.SessionData.SessionType == SessionType.Race || Utilities.random.Next(10) < frequencyOfOpponentPracticeAndQualLapTimes))
                                 {
                                     // he's behind us, and has recorded 3 or more laps, and this one's his fastest
                                     Console.WriteLine("Car behind fast lap - this lap time = " + opponentData.LastLapTime + " session best = " + currentFastestLap);
-                                    audioPlayer.playMessage(new QueuedMessage("car_behind_good_laptime", MessageContents(folderTheCarBehindHasJustDoneA,
-                                            TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)), 0, this), 0);
+                                    audioPlayer.playMessage(new QueuedMessage("car_behind_good_laptime", 5,
+                                        messageFragments: MessageContents(folderTheCarBehindHasJustDoneA, TimeSpanWrapper.FromSeconds(opponentData.LastLapTime, Precision.AUTO_LAPTIMES)),
+                                        abstractEvent: this, priority: 0));
                                 }
                             }
                         }
@@ -335,7 +340,8 @@ namespace CrewChiefV4.Events
                             }
                             if (AudioPlayer.canReadName(retiredDriver))
                             {
-                                audioPlayer.playMessage(new QueuedMessage("retirement", MessageContents(DriverNameHelper.getUsableDriverName(retiredDriver), folderHasJustRetired), 0, this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("retirement", 10,
+                                    messageFragments: MessageContents(DriverNameHelper.getUsableDriverName(retiredDriver), folderHasJustRetired), abstractEvent: this, priority: 0));
                             }
                         }
                     }
@@ -346,7 +352,8 @@ namespace CrewChiefV4.Events
                             announcedRetirementsAndDQs.Add(dqDriver);
                             if (AudioPlayer.canReadName(dqDriver))
                             {
-                                audioPlayer.playMessage(new QueuedMessage("retirement", MessageContents(DriverNameHelper.getUsableDriverName(dqDriver), folderHasJustBeenDisqualified), 0, this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("retirement", 10,
+                                    messageFragments: MessageContents(DriverNameHelper.getUsableDriverName(dqDriver), folderHasJustBeenDisqualified), abstractEvent: this, priority: 0));
                             }
                         }
                     }
@@ -368,9 +375,11 @@ namespace CrewChiefV4.Events
                                         (!onlyAnnounceOpponentAfter.TryGetValue(opponentName, out announceAfterTime) || currentGameState.Now > announceAfterTime))
                                     {
                                         Console.WriteLine("New car ahead: " + opponentName);
-                                        audioPlayer.playMessage(new QueuedMessage("new_car_ahead", MessageContents(folderNextCarIs, opponentData),
-                                            Utilities.random.Next(Position.maxSecondsToWaitBeforeReportingPass + 1, Position.maxSecondsToWaitBeforeReportingPass + 3), this,
-                                            new Dictionary<string, object> { { validationDriverAheadKey, opponentData.DriverRawName } }), 7);
+                                        int delay = Utilities.random.Next(Position.maxSecondsToWaitBeforeReportingPass + 1, Position.maxSecondsToWaitBeforeReportingPass + 3);
+                                        audioPlayer.playMessage(new QueuedMessage("new_car_ahead", delay + 2, secondsDelay: delay,
+                                            messageFragments: MessageContents(folderNextCarIs, opponentData), abstractEvent: this,
+                                            validationData: new Dictionary<string, object> { { validationDriverAheadKey, opponentData.DriverRawName } },
+                                            priority: 7));
                                         nextCarAheadChangeMessage = currentGameState.Now.Add(TimeSpan.FromSeconds(30));
                                         onlyAnnounceOpponentAfter[opponentName] = currentGameState.Now.Add(waitBeforeAnnouncingSameOpponentAhead);
                                         lastNextCarAheadOpponentName = opponentName;
@@ -389,8 +398,9 @@ namespace CrewChiefV4.Events
                                     currentGameState.Now > nextLeadChangeMessage && leader.CanUseName && AudioPlayer.canReadName(name))
                                 {
                                     Console.WriteLine("Lead change, current leader is " + name + " laps completed = " + currentGameState.SessionData.CompletedLaps);
-                                    audioPlayer.playMessage(new QueuedMessage("new_leader", MessageContents(leader, folderIsNowLeading), 2, this,
-                                        new Dictionary<string, object> { { validationNewLeaderKey, name } }), 3);
+                                    audioPlayer.playMessage(new QueuedMessage("new_leader", 4, secondsDelay:2,
+                                        messageFragments: MessageContents(leader, folderIsNowLeading), abstractEvent: this,
+                                        validationData: new Dictionary<string, object> { { validationNewLeaderKey, name } }, priority: 3));
                                     nextLeadChangeMessage = currentGameState.Now.Add(TimeSpan.FromSeconds(60));
                                     lastLeaderAnnounced = name;
                                 }
@@ -404,8 +414,10 @@ namespace CrewChiefV4.Events
                     currentGameState.SessionData.SessionPhase != SessionPhase.Countdown && currentGameState.SessionData.SessionPhase != SessionPhase.Formation &&
                     !Strategy.opponentsWhoWillExitCloseInFront.Contains(currentGameState.PitData.OpponentForLeaderPitting.DriverRawName))
                 {
-                    audioPlayer.playMessage(new QueuedMessage("leader_is_pitting", MessageContents(folderTheLeader, currentGameState.PitData.OpponentForLeaderPitting,
-                        folderIsPitting), MessageContents(folderLeaderIsPitting), 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage("leader_is_pitting", 10,
+                        messageFragments: MessageContents(folderTheLeader, currentGameState.PitData.OpponentForLeaderPitting,
+                        folderIsPitting), 
+                        alternateMessageFragments: MessageContents(folderLeaderIsPitting), abstractEvent: this, priority: 3));
                     announcedPitters.Add(currentGameState.PitData.OpponentForLeaderPitting.DriverRawName);
                 }
 
@@ -413,8 +425,10 @@ namespace CrewChiefV4.Events
                     currentGameState.SessionData.SessionPhase != SessionPhase.Countdown && currentGameState.SessionData.SessionPhase != SessionPhase.Formation &&
                     !Strategy.opponentsWhoWillExitCloseInFront.Contains(currentGameState.PitData.OpponentForCarAheadPitting.DriverRawName))
                 {
-                    audioPlayer.playMessage(new QueuedMessage("car_in_front_is_pitting", MessageContents(currentGameState.PitData.OpponentForCarAheadPitting,
-                        folderAheadIsPitting), MessageContents(folderCarAheadIsPitting), 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage("car_in_front_is_pitting", 10,
+                        messageFragments: MessageContents(currentGameState.PitData.OpponentForCarAheadPitting,
+                        folderAheadIsPitting), 
+                        alternateMessageFragments: MessageContents(folderCarAheadIsPitting), abstractEvent: this, priority: 3));
                     announcedPitters.Add(currentGameState.PitData.OpponentForCarAheadPitting.DriverRawName);
                 }
 
@@ -422,8 +436,10 @@ namespace CrewChiefV4.Events
                     currentGameState.SessionData.SessionPhase != SessionPhase.Countdown && currentGameState.SessionData.SessionPhase != SessionPhase.Formation &&
                     !Strategy.opponentsWhoWillExitCloseBehind.Contains(currentGameState.PitData.OpponentForCarBehindPitting.DriverRawName))
                 {
-                    audioPlayer.playMessage(new QueuedMessage("car_behind_is_pitting", MessageContents(currentGameState.PitData.OpponentForCarBehindPitting,
-                        folderBehindIsPitting), MessageContents(folderCarBehindIsPitting), 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage("car_behind_is_pitting", 10,
+                        messageFragments: MessageContents(currentGameState.PitData.OpponentForCarBehindPitting,
+                        folderBehindIsPitting),
+                        alternateMessageFragments: MessageContents(folderCarBehindIsPitting), abstractEvent: this, priority: 3));
                     announcedPitters.Add(currentGameState.PitData.OpponentForCarBehindPitting.DriverRawName);
                 }
                 if (Strategy.opponentFrontToWatchForPitting != null && !announcedPitters.Contains(Strategy.opponentFrontToWatchForPitting))
@@ -434,8 +450,10 @@ namespace CrewChiefV4.Events
                         {
                             if (entry.Value.InPits)
                             {
-                                audioPlayer.playMessage(new QueuedMessage("car_is_pitting", MessageContents(entry.Value,
-                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting), 0, this), 3);
+                                audioPlayer.playMessage(new QueuedMessage("car_is_pitting", 10,
+                                    messageFragments: MessageContents(entry.Value, 
+                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting),
+                                    abstractEvent: this, priority: 3));
                                 Strategy.opponentFrontToWatchForPitting = null;
                                 break;
                             }
@@ -450,8 +468,10 @@ namespace CrewChiefV4.Events
                         {
                             if (entry.Value.InPits)
                             {
-                                audioPlayer.playMessage(new QueuedMessage("car_is_pitting", MessageContents(entry.Value,
-                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting), 0, this), 3);
+                                audioPlayer.playMessage(new QueuedMessage("car_is_pitting", 10,
+                                    messageFragments: MessageContents(entry.Value,
+                                    currentGameState.SessionData.ClassPosition > entry.Value.ClassPosition ? folderAheadIsPitting : folderBehindIsPitting),
+                                    abstractEvent: this, priority: 3));
                                 Strategy.opponentBehindToWatchForPitting = null;
                                 break;
                             }
@@ -613,8 +633,8 @@ namespace CrewChiefV4.Events
                         if (lastLap != -1)
                         {
                             gotData = true;
-                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentLastLap", MessageContents(
-                                TimeSpanWrapper.FromSeconds(lastLap, Precision.AUTO_LAPTIMES)), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentLastLap", 0, 
+                                messageFragments: MessageContents(TimeSpanWrapper.FromSeconds(lastLap, Precision.AUTO_LAPTIMES))));
 
                         }
                     }
@@ -624,8 +644,8 @@ namespace CrewChiefV4.Events
                         if (bestLap != -1)
                         {
                             gotData = true;
-                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentBestLap", MessageContents(
-                                TimeSpanWrapper.FromSeconds(bestLap, Precision.AUTO_LAPTIMES)), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentBestLap", 0, 
+                                messageFragments:  MessageContents(TimeSpanWrapper.FromSeconds(bestLap, Precision.AUTO_LAPTIMES))));
 
                         }
                     }
@@ -669,7 +689,7 @@ namespace CrewChiefV4.Events
                             if (gotData)
                             {
                                 messageFragments.AddRange(MessageContents(wholeandfractional.Item1, NumberReader.folderPoint, wholeandfractional.Item2));
-                                QueuedMessage licenceLevelMessage = new QueuedMessage("License/license", messageFragments, 0, null);
+                                QueuedMessage licenceLevelMessage = new QueuedMessage("License/license", 0, messageFragments: messageFragments);
                                 audioPlayer.playDelayedImmediateMessage(licenceLevelMessage);
                             }
                         }
@@ -680,7 +700,7 @@ namespace CrewChiefV4.Events
                         if (rating != -1)
                         {
                             gotData = true;
-                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentiRating", MessageContents(rating), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentiRating", 0, messageFragments:  MessageContents(rating)));
                         }
                     }
                 }
@@ -707,11 +727,13 @@ namespace CrewChiefV4.Events
                                 {
                                     if (SoundCache.availableSounds.Contains(folderOpponentPositionIntro))
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentPosition", MessageContents(folderOpponentPositionIntro, Position.folderStub + position), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentPosition", 0, 
+                                            messageFragments: MessageContents(folderOpponentPositionIntro, Position.folderStub + position)));
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentPosition", MessageContents(Position.folderStub + position), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentPosition", 0, 
+                                            messageFragments: MessageContents(Position.folderStub + position)));
                                     }
                                     gotData = true;
                                 }
@@ -725,18 +747,18 @@ namespace CrewChiefV4.Events
                                     {
                                         if (SoundCache.availableSounds.Contains(folderOpponentPositionIntro))
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), folderOneLapBehind), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                                messageFragments: MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), folderOneLapBehind)));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                               MessageContents(Position.folderStub + position, Pause(200), folderOneLapBehind), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                               messageFragments: MessageContents(Position.folderStub + position, Pause(200), folderOneLapBehind)));
                                         }
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", MessageContents(folderOneLapBehind), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, messageFragments: MessageContents(folderOneLapBehind)));
                                     }
                                 }
                                 else if (lapDifference > 1)
@@ -745,19 +767,20 @@ namespace CrewChiefV4.Events
                                     {
                                         if (SoundCache.availableSounds.Contains(folderOpponentPositionIntro))
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), lapDifference, Position.folderLapsBehind), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                                messageFragments: MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200),
+                                                    lapDifference, Position.folderLapsBehind)));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                               MessageContents(Position.folderStub + position, Pause(200), lapDifference, Position.folderLapsBehind), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, 
+                                               messageFragments: MessageContents(Position.folderStub + position, Pause(200), lapDifference, Position.folderLapsBehind)));
                                         }
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                            MessageContents(lapDifference, Position.folderLapsBehind), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                            messageFragments: MessageContents(lapDifference, Position.folderLapsBehind)));
                                     }
                                 }
                                 else if (lapDifference == -1)
@@ -766,18 +789,19 @@ namespace CrewChiefV4.Events
                                     {
                                         if (SoundCache.availableSounds.Contains(folderOpponentPositionIntro))
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), folderOneLapAhead), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, 
+                                                messageFragments: MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), folderOneLapAhead)));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(Position.folderStub + position, Pause(200), folderOneLapAhead), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, 
+                                                messageFragments: MessageContents(Position.folderStub + position, Pause(200), folderOneLapAhead)));
                                         }
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", MessageContents(folderOneLapAhead), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, 
+                                            messageFragments: MessageContents(folderOneLapAhead)));
                                     }
                                 }
                                 else if (lapDifference < -1)
@@ -786,19 +810,20 @@ namespace CrewChiefV4.Events
                                     {
                                         if (SoundCache.availableSounds.Contains(folderOpponentPositionIntro))
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), Math.Abs(lapDifference), Position.folderLapsAhead), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                                messageFragments: MessageContents(folderOpponentPositionIntro, Position.folderStub + position, 
+                                                    Pause(200), Math.Abs(lapDifference), Position.folderLapsAhead)));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(Position.folderStub + position, Pause(200), Math.Abs(lapDifference), Position.folderLapsAhead), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                                messageFragments: MessageContents(Position.folderStub + position, Pause(200), Math.Abs(lapDifference), Position.folderLapsAhead)));
                                         }
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                            MessageContents(Math.Abs(lapDifference), Position.folderLapsAhead), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                            messageFragments: MessageContents(Math.Abs(lapDifference), Position.folderLapsAhead)));
                                     }
                                 }
                                 else
@@ -813,19 +838,18 @@ namespace CrewChiefV4.Events
                                     {
                                         if (SoundCache.availableSounds.Contains(folderOpponentPositionIntro))
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                                MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), delta, aheadOrBehind), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, 
+                                                messageFragments: MessageContents(folderOpponentPositionIntro, Position.folderStub + position, Pause(200), delta, aheadOrBehind)));
                                         }
                                         else
                                         {
-                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                               MessageContents(Position.folderStub + position, Pause(200), delta, aheadOrBehind), 0, null));
+                                            audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0,
+                                               messageFragments: MessageContents(Position.folderStub + position, Pause(200), delta, aheadOrBehind)));
                                         }
                                     }
                                     else
                                     {
-                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta",
-                                            MessageContents(delta, aheadOrBehind), 0, null));
+                                        audioPlayer.playMessageImmediately(new QueuedMessage("opponentTimeDelta", 0, messageFragments: MessageContents(delta, aheadOrBehind)));
                                     }
                                 }
                             }
@@ -846,14 +870,14 @@ namespace CrewChiefV4.Events
                         QueuedMessage queuedMessage;
                         if (AudioPlayer.ttsOption != AudioPlayer.TTS_OPTION.NEVER)
                         {
-                            queuedMessage = new QueuedMessage("opponentNameAndPosition", MessageContents(opponent,
-                                    Position.folderStub + opponent.ClassPosition), 0, null);
+                            queuedMessage = new QueuedMessage("opponentNameAndPosition", 0, 
+                                messageFragments: MessageContents(opponent, Position.folderStub + opponent.ClassPosition));
                         }
                         else
                         {
-                            queuedMessage = new QueuedMessage("opponentNameAndPosition", MessageContents(opponent,
-                                    Position.folderStub + opponent.ClassPosition),
-                                    MessageContents(Position.folderStub + opponent.ClassPosition, folderCantPronounceName), 0, null);
+                            queuedMessage = new QueuedMessage("opponentNameAndPosition", 0, 
+                                messageFragments: MessageContents(opponent, Position.folderStub + opponent.ClassPosition),
+                                alternateMessageFragments: MessageContents(Position.folderStub + opponent.ClassPosition, folderCantPronounceName));
                         }
                         if (queuedMessage.canBePlayed)
                         {
@@ -871,14 +895,14 @@ namespace CrewChiefV4.Events
                         QueuedMessage queuedMessage;
                         if (AudioPlayer.ttsOption != AudioPlayer.TTS_OPTION.NEVER)
                         {
-                            queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent,
-                                    Position.folderStub + opponent.ClassPosition), 0, null);
+                            queuedMessage = new QueuedMessage("opponentName", 0,
+                                messageFragments: MessageContents(opponent, Position.folderStub + opponent.ClassPosition));
                         }
                         else
                         {
-                            queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent,
-                                    Position.folderStub + opponent.ClassPosition),
-                                    MessageContents(Position.folderStub + opponent.ClassPosition, folderCantPronounceName), 0, null);
+                            queuedMessage = new QueuedMessage("opponentName", 0,
+                                messageFragments: MessageContents(opponent, Position.folderStub + opponent.ClassPosition),
+                                alternateMessageFragments: MessageContents(Position.folderStub + opponent.ClassPosition, folderCantPronounceName));
                         }
 
                         if (queuedMessage.canBePlayed)
@@ -893,7 +917,7 @@ namespace CrewChiefV4.Events
                 {
                     if (currentGameState.isLast())
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(Position.folderLast, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(Position.folderLast, 0));
 
                         gotData = true;
                     }
@@ -905,11 +929,12 @@ namespace CrewChiefV4.Events
                             QueuedMessage queuedMessage;
                             if (AudioPlayer.ttsOption != AudioPlayer.TTS_OPTION.NEVER)
                             {
-                                queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), 0, null);
+                                queuedMessage = new QueuedMessage("opponentName", 0, messageFragments: MessageContents(opponent));
                             }
                             else
                             {
-                                queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), MessageContents(folderCantPronounceName), 0, null);
+                                queuedMessage = new QueuedMessage("opponentName", 0,
+                                    messageFragments: MessageContents(opponent), alternateMessageFragments: MessageContents(folderCantPronounceName));
                             }
 
                             if (queuedMessage.canBePlayed)
@@ -937,11 +962,12 @@ namespace CrewChiefV4.Events
                             QueuedMessage queuedMessage;
                             if (AudioPlayer.ttsOption != AudioPlayer.TTS_OPTION.NEVER)
                             {
-                                queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), 0, null);
+                                queuedMessage = new QueuedMessage("opponentName", 0, messageFragments: MessageContents(opponent));
                             }
                             else
                             {
-                                queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), MessageContents(folderCantPronounceName), 0, null);
+                                queuedMessage = new QueuedMessage("opponentName", 0, messageFragments: MessageContents(opponent), 
+                                    alternateMessageFragments: MessageContents(folderCantPronounceName));
                             }
 
                             if (queuedMessage.canBePlayed)
@@ -961,11 +987,12 @@ namespace CrewChiefV4.Events
                         QueuedMessage queuedMessage;
                         if (AudioPlayer.ttsOption != AudioPlayer.TTS_OPTION.NEVER)
                         {
-                            queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), 0, null);
+                            queuedMessage = new QueuedMessage("opponentName", 0, messageFragments: MessageContents(opponent));
                         }
                         else
                         {
-                            queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), MessageContents(folderCantPronounceName), 0, null);
+                            queuedMessage = new QueuedMessage("opponentName",0, messageFragments: MessageContents(opponent),
+                                alternateMessageFragments: MessageContents(folderCantPronounceName));
                         }
                         if (queuedMessage.canBePlayed)
                         {
@@ -992,11 +1019,12 @@ namespace CrewChiefV4.Events
                             QueuedMessage queuedMessage;
                             if (AudioPlayer.ttsOption != AudioPlayer.TTS_OPTION.NEVER)
                             {
-                                queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), 0, null);
+                                queuedMessage = new QueuedMessage("opponentName", 0, messageFragments: MessageContents(opponent));
                             }
                             else
                             {
-                                queuedMessage = new QueuedMessage("opponentName", MessageContents(opponent), MessageContents(folderCantPronounceName), 0, null);
+                                queuedMessage = new QueuedMessage("opponentName", 0, messageFragments: MessageContents(opponent),
+                                    alternateMessageFragments: MessageContents(folderCantPronounceName));
                             }
                             if (queuedMessage.canBePlayed)
                             {

--- a/CrewChiefV4/Events/OvertakingAidsMonitor.cs
+++ b/CrewChiefV4/Events/OvertakingAidsMonitor.cs
@@ -64,8 +64,8 @@ namespace CrewChiefV4.Events
                 {
                     if (drsAvailableOnThisLap && !hasUsedDrsOnThisLap)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("missed_available_drs", 0, 
-                            messageFragments: MessageContents(folderDontForgetDRS), abstractEvent: this), 0);
+                        audioPlayer.playMessage(new QueuedMessage("missed_available_drs", 3, 
+                            messageFragments: MessageContents(folderDontForgetDRS), abstractEvent: this, priority: 0));
                     }
                     drsAvailableOnThisLap = currentGameState.OvertakingAids.DrsAvailable;
                     hasUsedDrsOnThisLap = false;
@@ -89,7 +89,7 @@ namespace CrewChiefV4.Events
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
                             audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", 3,
-                                messageFragments: MessageContents(folderASecondOffDRSRange), abstractEvent: this), 10);
+                                messageFragments: MessageContents(folderASecondOffDRSRange), abstractEvent: this, priority: 10));
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -99,7 +99,7 @@ namespace CrewChiefV4.Events
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
                             audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", 3,
-                                messageFragments:  MessageContents(folderAFewTenthsOffDRSRange), abstractEvent: this), 10);
+                                messageFragments:  MessageContents(folderAFewTenthsOffDRSRange), abstractEvent: this, priority: 10));
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -114,7 +114,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, false /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderGuyBehindHasDRS, 3, abstractEvent: this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderGuyBehindHasDRS, 3, abstractEvent: this, priority: 10));
                         }
                     }
                 }
@@ -134,7 +134,7 @@ namespace CrewChiefV4.Events
                     if (currentGameState.OvertakingAids.PushToPassActivationsRemaining == 1)
                     {
                         audioPlayer.playMessage(new QueuedMessage("one_push_to_pass_remaining", 10, 
-                            messageFragments: MessageContents(folderPushToPassNowAvailable, folderOneActivationRemaining), abstractEvent: this), 7);
+                            messageFragments: MessageContents(folderPushToPassNowAvailable, folderOneActivationRemaining), abstractEvent: this, priority: 7));
                         pushToPassActivationsRemaining = 1;
                     }
                     else if (currentGameState.OvertakingAids.PushToPassActivationsRemaining > 0)
@@ -147,7 +147,7 @@ namespace CrewChiefV4.Events
                     else
                     {
                         audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", 10,
-                            messageFragments: MessageContents(folderNoActivationsRemaining), abstractEvent: this, priority: 5);
+                            messageFragments: MessageContents(folderNoActivationsRemaining), abstractEvent: this, priority: 5));
                         pushToPassActivationsRemaining = 0;
                     }
                 }

--- a/CrewChiefV4/Events/OvertakingAidsMonitor.cs
+++ b/CrewChiefV4/Events/OvertakingAidsMonitor.cs
@@ -64,7 +64,8 @@ namespace CrewChiefV4.Events
                 {
                     if (drsAvailableOnThisLap && !hasUsedDrsOnThisLap)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("missed_available_drs", MessageContents(folderDontForgetDRS), 0, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage("missed_available_drs", 0, 
+                            messageFragments: MessageContents(folderDontForgetDRS), abstractEvent: this), 0);
                     }
                     drsAvailableOnThisLap = currentGameState.OvertakingAids.DrsAvailable;
                     hasUsedDrsOnThisLap = false;
@@ -87,7 +88,8 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", MessageContents(folderASecondOffDRSRange), 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("drs_a_second_out_of_range", 3,
+                                messageFragments: MessageContents(folderASecondOffDRSRange), abstractEvent: this), 10);
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -96,7 +98,8 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, true /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", MessageContents(folderAFewTenthsOffDRSRange), 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage("drs_a_few_tenths_out_of_range", 3,
+                                messageFragments:  MessageContents(folderAFewTenthsOffDRSRange), abstractEvent: this), 10);
                             playedGetCloserForDRSOnThisLap = true;
                         }
                     }
@@ -111,7 +114,7 @@ namespace CrewChiefV4.Events
                     {
                         if (ImmediateOpponentIsValidForDRSMessage(currentGameState, false /*inFront*/))
                         {
-                            audioPlayer.playMessage(new QueuedMessage("opponent_has_drs", MessageContents(folderGuyBehindHasDRS), 0, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderGuyBehindHasDRS, 3, abstractEvent: this), 10);
                         }
                     }
                 }
@@ -123,26 +126,28 @@ namespace CrewChiefV4.Events
                 if (previousGameState.OvertakingAids.PushToPassEngaged && !currentGameState.OvertakingAids.PushToPassEngaged &&
                     currentGameState.OvertakingAids.PushToPassActivationsRemaining == 0)
                 {
-                    audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", MessageContents(folderNoActivationsRemaining), 0, this), 5);
+                    audioPlayer.playMessage(new QueuedMessage(folderNoActivationsRemaining, 10, abstractEvent: this, priority: 5));
                     pushToPassActivationsRemaining = 0;
                 }
                 else if (previousGameState.OvertakingAids.PushToPassWaitTimeLeft > 0 && currentGameState.OvertakingAids.PushToPassWaitTimeLeft == 0)
                 {
                     if (currentGameState.OvertakingAids.PushToPassActivationsRemaining == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("one_push_to_pass_remaining", MessageContents(
-                            folderPushToPassNowAvailable, folderOneActivationRemaining), 0, this), 7);
+                        audioPlayer.playMessage(new QueuedMessage("one_push_to_pass_remaining", 10, 
+                            messageFragments: MessageContents(folderPushToPassNowAvailable, folderOneActivationRemaining), abstractEvent: this), 7);
                         pushToPassActivationsRemaining = 1;
                     }
                     else if (currentGameState.OvertakingAids.PushToPassActivationsRemaining > 0)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("push_to_pass_remaining", MessageContents(folderPushToPassNowAvailable,
-                            currentGameState.OvertakingAids.PushToPassActivationsRemaining, folderActivationsRemaining), 0, this), 2);
+                        audioPlayer.playMessage(new QueuedMessage("push_to_pass_remaining", 5, 
+                            messageFragments: MessageContents(folderPushToPassNowAvailable, currentGameState.OvertakingAids.PushToPassActivationsRemaining, folderActivationsRemaining), 
+                            abstractEvent: this, priority: 2));
                         pushToPassActivationsRemaining = currentGameState.OvertakingAids.PushToPassActivationsRemaining;
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", MessageContents(folderNoActivationsRemaining), 0, this), 5);
+                        audioPlayer.playMessage(new QueuedMessage("no_push_to_pass_remaining", 10,
+                            messageFragments: MessageContents(folderNoActivationsRemaining), abstractEvent: this, priority: 5);
                         pushToPassActivationsRemaining = 0;
                     }
                 }

--- a/CrewChiefV4/Events/Penalties.cs
+++ b/CrewChiefV4/Events/Penalties.cs
@@ -160,9 +160,9 @@ namespace CrewChiefV4.Events
                 {
                     lapsCompleted = currentGameState.SessionData.CompletedLaps;
                     // this is a new penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyDriveThrough, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyDriveThrough, 0, abstractEvent: this, priority: 10));
                     // queue a '3 laps to serve penalty' message - this might not get played
-                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 20, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 0, secondsDelay: pitstopDelay, abstractEvent: this, priority: 10));
                     // we don't already have a penalty
                     if (penaltyLap == -1 || !hasOutstandingPenalty)
                     {
@@ -175,9 +175,9 @@ namespace CrewChiefV4.Events
                 {
                     lapsCompleted = currentGameState.SessionData.CompletedLaps;
                     // this is a new penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyStopGo, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderNewPenaltyStopGo, 0, abstractEvent: this, priority: 10));
                     // queue a '3 laps to serve penalty' message - this might not get played
-                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 20, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, 0, secondsDelay: pitstopDelay, abstractEvent: this, priority: 10));
                     // we don't already have a penalty
                     if (penaltyLap == -1 || !hasOutstandingPenalty)
                     {
@@ -190,7 +190,7 @@ namespace CrewChiefV4.Events
                     (currentGameState.PenaltiesData.HasStopAndGo || currentGameState.PenaltiesData.HasDriveThrough))
                 {
                     // we've exited the pits but there's still an outstanding penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 3, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 0, secondsDelay: 3, abstractEvent: this, priority: 10));
                     playedNotServedPenalty = true;
                 } 
                 else if (currentGameState.SessionData.IsNewLap && (currentGameState.PenaltiesData.HasStopAndGo || currentGameState.PenaltiesData.HasDriveThrough))
@@ -201,36 +201,36 @@ namespace CrewChiefV4.Events
                         // run out of laps, and not in the pitlane
                         if (!audioPlayer.playRant("disqualified_rant", MessageContents(folderDisqualified)))
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderDisqualified, 5, this), 10);
+                            audioPlayer.playMessage(new QueuedMessage(folderDisqualified, 0, secondsDelay: 5, abstractEvent: this, priority: 10));
                         }
                     }
                     else if (lapsCompleted - penaltyLap == 2 && currentGameState.PenaltiesData.HasDriveThrough)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeDriveThrough, pitstopDelay, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeDriveThrough, 0, secondsDelay: pitstopDelay, abstractEvent: this, priority: 10));
                     }
                     else if (lapsCompleted - penaltyLap == 2 && currentGameState.PenaltiesData.HasStopAndGo)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeStopGo, pitstopDelay, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderOneLapToServeStopGo, 0, secondsDelay: pitstopDelay, abstractEvent: this, priority: 10));
                     }
                     else if (lapsCompleted - penaltyLap == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, 0, secondsDelay: pitstopDelay, abstractEvent: this, priority: 10));
                     }
                 }
                 else if (!playedPitNow && currentGameState.SessionData.SectorNumber == 3 && currentGameState.PenaltiesData.HasStopAndGo && lapsCompleted - penaltyLap == 2)
                 {
                     playedPitNow = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderPitNowStopGo, 6, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderPitNowStopGo, 14, secondsDelay: 6, abstractEvent: this, priority: 10));
                 }
                 else if (!playedPitNow && currentGameState.SessionData.SectorNumber == 3 && currentGameState.PenaltiesData.HasDriveThrough && lapsCompleted - penaltyLap == 2)
                 {
                     playedPitNow = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderPitNowDriveThrough, 6, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderPitNowDriveThrough, 14, secondsDelay: 6, abstractEvent: this, priority: 10));
                 }
                 else if (!playedTimePenaltyMessage && currentGameState.PenaltiesData.HasTimeDeduction)
                 {
                     playedTimePenaltyMessage = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderTimePenalty, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderTimePenalty, 0, abstractEvent: this, priority: 10));
                 }
             }
             else if (currentGameState.PositionAndMotionData.CarSpeed > 1 && playCutTrackWarnings && 
@@ -248,7 +248,7 @@ namespace CrewChiefV4.Events
                     {
                         if (currentGameState.SessionData.SessionType == SessionType.Race)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderCutTrackInRace, 2, this), 3);
+                            audioPlayer.playMessage(new QueuedMessage(folderCutTrackInRace, 5, secondsDelay: 2, abstractEvent: this, priority: 3));
                         }
                         else if (!playedTrackCutWarningInPracticeOrQualOnThisLap)
                         {
@@ -257,11 +257,11 @@ namespace CrewChiefV4.Events
                                 && currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance != -1.0f
                                 && currentGameState.PositionAndMotionData.DistanceRoundTrack > currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance)
                             {
-                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 2, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 5, secondsDelay: 2, abstractEvent: this, priority: 10));
                             }
                             else
                             {
-                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 2, this), 10);
+                                audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 5, secondsDelay: 5, abstractEvent: this, priority: 10));
                             }
                             playedTrackCutWarningInPracticeOrQualOnThisLap = true;
                         }
@@ -285,11 +285,11 @@ namespace CrewChiefV4.Events
                         && currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance != -1.0f
                         && currentGameState.PositionAndMotionData.DistanceRoundTrack > currentGameState.SessionData.TrackDefinition.raceroomRollingStartLapDistance)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 2, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQualNextLapInvalid, 5, secondsDelay: 2, abstractEvent: this, priority: 10));
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 2, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(Utilities.random.NextDouble() < 0.3 ? folderLapDeleted : folderCutTrackPracticeOrQual, 5, secondsDelay: 2, abstractEvent: this, priority: 10));
                     }
                     clearPenaltyState();
                 }
@@ -304,9 +304,11 @@ namespace CrewChiefV4.Events
                 {
                     lapsCompleted = currentGameState.SessionData.CompletedLaps;
                     // this is a new penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderYouHavePenalty, Utilities.random.Next(3, 7), this), 10);
+                    int delay1 = Utilities.random.Next(3, 7);
+                    int delay2 = Utilities.random.Next(10, 20);
+                    audioPlayer.playMessage(new QueuedMessage(folderYouHavePenalty, delay1 + 6, secondsDelay: delay1, abstractEvent: this, priority: 10));
                     // queue a '3 laps to serve penalty' message - this might not get played
-                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, Utilities.random.Next(10, 20), this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderThreeLapsToServe, delay2 + 6, secondsDelay: delay2, abstractEvent: this, priority: 10));
                     // we don't already have a penalty
                     if (penaltyLap == -1 || !hasOutstandingPenalty)
                     {
@@ -319,7 +321,7 @@ namespace CrewChiefV4.Events
                     currentGameState.PenaltiesData.NumPenalties > 0)
                 {
                     // we've exited the pits but there's still an outstanding penalty
-                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 3, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folderPenaltyNotServed, 0, secondsDelay: 3, abstractEvent: this, priority: 10));
                     playedNotServedPenalty = true;
                 }
                 else if (currentGameState.SessionData.IsNewLap && currentGameState.PenaltiesData.NumPenalties > 0)
@@ -328,18 +330,18 @@ namespace CrewChiefV4.Events
                     if (lapsCompleted - penaltyLap >= 2 && !currentGameState.PitData.InPitlane)
                     {
                         // run out of laps, an not in the pitlane
-                        audioPlayer.playMessage(new QueuedMessage(folderYouStillHavePenalty, 5, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderYouStillHavePenalty, 0, secondsDelay: 5, abstractEvent: this, priority: 10));
                     }
                     else if (lapsCompleted - penaltyLap == 1)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage(folderTwoLapsToServe, pitstopDelay + 6, secondsDelay: pitstopDelay, abstractEvent: this, priority: 10));
                     }
                 }
             }
             else if (currentGameState.PenaltiesData.PossibleTrackLimitsViolation && playCutTrackWarnings && !warnedOfPossibleTrackLimitsViolationOnThisLap)
             {
                 warnedOfPossibleTrackLimitsViolationOnThisLap = true;
-                audioPlayer.playMessage(new QueuedMessage(folderPossibleTrackLimitsViolation, 2 + Utilities.random.Next(3), this), 0);
+                audioPlayer.playMessage(new QueuedMessage(folderPossibleTrackLimitsViolation, 4, secondsDelay: 2, abstractEvent: this, priority: 0));
             }
             else
             {
@@ -352,7 +354,7 @@ namespace CrewChiefV4.Events
                 (previousGameState.PenaltiesData.NumPenalties > currentGameState.PenaltiesData.NumPenalties &&
                 (CrewChief.gameDefinition.gameEnum == GameEnum.RF1 || CrewChief.gameDefinition.gameEnum == GameEnum.RF2_64BIT))))
             {
-                audioPlayer.playMessage(new QueuedMessage(folderPenaltyServed, 0, this), 10);
+                audioPlayer.playMessage(new QueuedMessage(folderPenaltyServed, 0, abstractEvent: this, priority: 10));
             }            
         }
 
@@ -365,12 +367,12 @@ namespace CrewChiefV4.Events
                 {
                     if (lapsCompleted - penaltyLap == 2)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("youHaveAPenaltyBoxThisLap",
-                            MessageContents(folderYouHavePenalty, PitStops.folderMandatoryPitStopsPitThisLap), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("youHaveAPenaltyBoxThisLap", 0,
+                            messageFragments: MessageContents(folderYouHavePenalty, PitStops.folderMandatoryPitStopsPitThisLap)));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYouHavePenalty, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYouHavePenalty, 0));
                     }
                 }
             }
@@ -378,7 +380,7 @@ namespace CrewChiefV4.Events
             {
                 if (!hasHadAPenalty)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderYouDontHaveAPenalty, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderYouDontHaveAPenalty, 0));
                     return;
                 }
                 if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.DO_I_HAVE_A_PENALTY))
@@ -387,17 +389,17 @@ namespace CrewChiefV4.Events
                     {
                         if (lapsCompleted - penaltyLap == 2)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("youHaveAPenaltyBoxThisLap",
-                                MessageContents(folderYouHavePenalty, PitStops.folderMandatoryPitStopsPitThisLap), 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage("youHaveAPenaltyBoxThisLap", 0,
+                            messageFragments: MessageContents(folderYouHavePenalty, PitStops.folderMandatoryPitStopsPitThisLap)));
                         }
                         else
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage(folderYouHavePenalty, 0, null));
+                            audioPlayer.playMessageImmediately(new QueuedMessage(folderYouHavePenalty, 0));
                         }
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYouDontHaveAPenalty, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderYouDontHaveAPenalty, 0));
                     }
                 }
                 else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.HAVE_I_SERVED_MY_PENALTY))
@@ -411,12 +413,12 @@ namespace CrewChiefV4.Events
                         {
                             messages.Add(MessageFragment.Text(PitStops.folderMandatoryPitStopsPitThisLap));
                         }
-                        audioPlayer.playMessageImmediately(new QueuedMessage("noYouStillHaveAPenalty", messages, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("noYouStillHaveAPenalty", 0, messageFragments: messages));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("yesYouServedYourPenalty",
-                            MessageContents(AudioPlayer.folderYes, folderPenaltyServed), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("yesYouServedYourPenalty", 0,
+                            messageFragments: MessageContents(AudioPlayer.folderYes, folderPenaltyServed)));
                     }
                 }
                 else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.DO_I_STILL_HAVE_A_PENALTY))
@@ -430,12 +432,12 @@ namespace CrewChiefV4.Events
                         {
                             messages.Add(MessageFragment.Text(PitStops.folderMandatoryPitStopsPitThisLap));
                         }
-                        audioPlayer.playMessageImmediately(new QueuedMessage("yesYouStillHaveAPenalty", messages, 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("yesYouStillHaveAPenalty", 0, messageFragments: messages));
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("noYouServedYourPenalty",
-                            MessageContents(AudioPlayer.folderNo, folderPenaltyServed), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("noYouServedYourPenalty", 0,
+                            messageFragments: MessageContents(AudioPlayer.folderNo, folderPenaltyServed)));
                     }
                 }
             }

--- a/CrewChiefV4/Events/Position.cs
+++ b/CrewChiefV4/Events/Position.cs
@@ -274,8 +274,8 @@ namespace CrewChiefV4.Events
                             // allow an existing queued pearl to be played if it's type is 'good'
                             Dictionary<String, Object> validationData = new Dictionary<String, Object>();
                             validationData.Add(positionValidationKey, currentGameState.SessionData.ClassPosition);
-                            QueuedMessage overtakingMessage = new QueuedMessage(folderOvertaking, 0, this, validationData);
-                            audioPlayer.playMessage(overtakingMessage, PearlsOfWisdom.PearlType.GOOD, 0, 10);
+                            QueuedMessage overtakingMessage = new QueuedMessage(folderOvertaking, 3, abstractEvent: this, validationData: validationData, priority: 10);
+                            audioPlayer.playMessage(overtakingMessage, PearlsOfWisdom.PearlType.GOOD, 0);
                             reported = true;
                         }
                     }
@@ -316,8 +316,8 @@ namespace CrewChiefV4.Events
                             // allow an existing queued pearl to be played if it's type is 'bad'
                             Dictionary<String, Object> validationData = new Dictionary<String, Object>();
                             validationData.Add(positionValidationKey, currentGameState.SessionData.ClassPosition);
-                            QueuedMessage beingOvertakenMessage = new QueuedMessage(folderBeingOvertaken, 0, this, validationData);
-                            audioPlayer.playMessage(new QueuedMessage(folderBeingOvertaken, 0, this, validationData), PearlsOfWisdom.PearlType.BAD, 0, 10);
+                            QueuedMessage beingOvertakenMessage = new QueuedMessage(folderBeingOvertaken, 3, abstractEvent: this, validationData: validationData, priority: 10);
+                            audioPlayer.playMessage(beingOvertakenMessage, PearlsOfWisdom.PearlType.BAD, 0);
                             reported = true;
                         }
                     }
@@ -383,20 +383,20 @@ namespace CrewChiefV4.Events
                     {
                         if (currentGameState.SessionData.ClassPosition > currentGameState.SessionData.SessionStartClassPosition + 4)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderTerribleStart, 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderTerribleStart, 10, abstractEvent: this, priority: 5));
                         }
                         else if (currentGameState.SessionData.ClassPosition > currentGameState.SessionData.SessionStartClassPosition + 1)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderBadStart, 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderBadStart, 10, abstractEvent: this, priority: 5));
                         }
                         else if (!isLast && (currentGameState.SessionData.ClassPosition == 1 || currentGameState.SessionData.ClassPosition < currentGameState.SessionData.SessionStartClassPosition - 1))
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderGoodStart, 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderGoodStart, 10, abstractEvent: this, priority: 5));
                         }
                         else if (!isLast && Utilities.random.NextDouble() > 0.6)
                         {
                             // only play the OK start message sometimes
-                            audioPlayer.playMessage(new QueuedMessage(folderOKStart, 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderOKStart, 10, abstractEvent: this, priority: 5));
                         }
                     }
                 }
@@ -462,7 +462,7 @@ namespace CrewChiefV4.Events
                             CrewChief.gameDefinition.gameEnum == GameEnum.ASSETTO_64BIT ? 1 : 0;
                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("getPositionMessages", new Object[] { 
                             currentPosition }, this);
-                        audioPlayer.playMessage(new QueuedMessage("position", delayedMessageEvent:delayedMessageEvent, delaySeconds:delaySeconds), pearlType, pearlLikelihood, 10);
+                        audioPlayer.playMessage(new QueuedMessage("position", 10, delayedMessageEvent:delayedMessageEvent, secondsDelay: delaySeconds, priority: 10), pearlType, pearlLikelihood);
                         lapNumberAtLastMessage = currentGameState.SessionData.CompletedLaps;
                     }
                 }
@@ -522,7 +522,8 @@ namespace CrewChiefV4.Events
             {
                 if (SoundCache.availableSounds.Contains(folderDriverPositionIntro))
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("position", MessageContents(folderDriverPositionIntro, folderStub + currentPosition), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("position", 0,
+                        messageFragments: MessageContents(folderDriverPositionIntro, folderStub + currentPosition)));
                 }
                 else
                 {

--- a/CrewChiefV4/Events/Position.cs
+++ b/CrewChiefV4/Events/Position.cs
@@ -462,7 +462,7 @@ namespace CrewChiefV4.Events
                             CrewChief.gameDefinition.gameEnum == GameEnum.ASSETTO_64BIT ? 1 : 0;
                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("getPositionMessages", new Object[] { 
                             currentPosition }, this);
-                        audioPlayer.playMessage(new QueuedMessage("position", delayedMessageEvent, delaySeconds, null), pearlType, pearlLikelihood, 10);
+                        audioPlayer.playMessage(new QueuedMessage("position", delayedMessageEvent:delayedMessageEvent, delaySeconds:delaySeconds), pearlType, pearlLikelihood, 10);
                         lapNumberAtLastMessage = currentGameState.SessionData.CompletedLaps;
                     }
                 }

--- a/CrewChiefV4/Events/PushNow.cs
+++ b/CrewChiefV4/Events/PushNow.cs
@@ -101,11 +101,13 @@ namespace CrewChiefV4.Events
                 if (currentGameState.SessionData.SessionRunningTime > 30 && isOpponentApproachingPitExit(currentGameState))
                 {
                     // we've exited into clean air
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderTrafficBehindExitingPits, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderTrafficBehindExitingPits, 1, abstractEvent: this,
+                        type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderPushExitingPits, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderPushExitingPits, 1, abstractEvent: this,
+                        type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                 }
                 // now try and report the current brake and tyre temp status
                 try
@@ -129,16 +131,18 @@ namespace CrewChiefV4.Events
                     if (currentGameState.SessionData.SessionNumberOfLaps > 0)
                     {
                         // special case for iracing - AFAIK no other games have number-of-laps in qual sessions
-                        audioPlayer.playMessageImmediately(new QueuedMessage("qual_pit_exit", MessageContents(folderQualExitIntro,
-                            currentGameState.SessionData.SessionNumberOfLaps, folderQualExitOutroLaps), 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                        audioPlayer.playMessageImmediately(new QueuedMessage("qual_pit_exit", 2, 
+                            messageFragments: MessageContents(folderQualExitIntro, currentGameState.SessionData.SessionNumberOfLaps, folderQualExitOutroLaps),
+                            abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                     }
                     else if (currentGameState.SessionData.SessionHasFixedTime)
                     {
                         int minutesLeft = (int)Math.Floor(currentGameState.SessionData.SessionTimeRemaining / 60f);
                         if (minutesLeft > 1)
                         {
-                            audioPlayer.playMessageImmediately(new QueuedMessage("qual_pit_exit", MessageContents(folderQualExitIntro, minutesLeft, folderQualExitOutroMinutes), 0,
-                                this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                            audioPlayer.playMessageImmediately(new QueuedMessage("qual_pit_exit", 2,
+                                messageFragments: MessageContents(folderQualExitIntro, minutesLeft, folderQualExitOutroMinutes),
+                                abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                         }
                     }
                 }
@@ -150,7 +154,7 @@ namespace CrewChiefV4.Events
                 isApproachingStartLine(currentGameState.SessionData.TrackDefinition, previousGameState.PositionAndMotionData.DistanceRoundTrack, currentGameState.PositionAndMotionData.DistanceRoundTrack) &&
                 isOpponentLeavingPits(currentGameState))
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage(folderOpponentExitingPits, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                audioPlayer.playMessageImmediately(new QueuedMessage(folderOpponentExitingPits, 2, abstractEvent: this, type: SoundType.IMPORTANT_MESSAGE, priority: 0));
             }
         }
 
@@ -239,19 +243,19 @@ namespace CrewChiefV4.Events
                     // going flat out, we're going to catch the guy ahead us before the end
                     if (currentGameState.SessionData.ClassPosition == 2)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetWin, 0, this), 5);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetWin, 10, abstractEvent: this, priority: 5));
                     }
                     else if (currentGameState.SessionData.ClassPosition == 3)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetSecond, 0, this), 5);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetSecond, 10, abstractEvent: this, priority: 5));
                     }
                     else if (currentGameState.SessionData.ClassPosition == 4)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetThird, 0, this), 5);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToGetThird, 10, abstractEvent: this, priority: 5));
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folderPushToImprove, 0, this), 5);
+                        audioPlayer.playMessage(new QueuedMessage(folderPushToImprove, 10, abstractEvent: this, priority: 5));
                     }
                     return true;
                 }
@@ -265,7 +269,7 @@ namespace CrewChiefV4.Events
                     // even with us going flat out, the guy behind is going to catch us before the end
                     Console.WriteLine("Might lose this position. Player best lap = " + currentGameState.SessionData.PlayerLapTimeSessionBest.ToString("0.000") + " laps left = " + numLapsLeft +
                         " opponent best lap = " + opponentBehindBestLap.ToString("0.000") + " time delta = " + currentGameState.SessionData.TimeDeltaBehind.ToString("0.000"));
-                    audioPlayer.playMessage(new QueuedMessage(folderPushToHoldPosition, 0, this), 3);
+                    audioPlayer.playMessage(new QueuedMessage(folderPushToHoldPosition, 10, abstractEvent: this, priority: 3));
                     return true;
                 }
             }

--- a/CrewChiefV4/Events/RaceTime.cs
+++ b/CrewChiefV4/Events/RaceTime.cs
@@ -156,16 +156,16 @@ namespace CrewChiefV4.Events
                         if (currentGameState.SessionData.ClassPosition == 1)
                         {
                             // don't add a pearl here - the audio clip already contains encouragement
-                            audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 0, this), pearlType, 0, 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderLastLapLeading, 10, abstractEvent: this, priority: 5), pearlType, 0);
                         }
                         else if (currentGameState.SessionData.ClassPosition < 4)
                         {
                             // don't add a pearl here - the audio clip already contains encouragement
-                            audioPlayer.playMessage(new QueuedMessage(folderLastLapPodium, 0, this), pearlType, 0, 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderLastLapPodium, 10, abstractEvent: this, priority: 5), pearlType, 0);
                         }
                         else
                         {
-                            audioPlayer.playMessage(new QueuedMessage(folderLastLap, 0, this), 5);
+                            audioPlayer.playMessage(new QueuedMessage(folderLastLap, 10, abstractEvent: this, priority: 5));
                         }
                     }
                 }
@@ -194,8 +194,8 @@ namespace CrewChiefV4.Events
                     else if (currentGameState.SessionData.SessionType != SessionType.Race) 
                     {
                         // don't play the chequered flag message in race sessions
-                        audioPlayer.playMessage(new QueuedMessage("session_complete",
-                            MessageContents(folder0mins, Position.folderStub + currentGameState.SessionData.ClassPosition), 0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage("session_complete", 5,
+                            messageFragments: MessageContents(folder0mins, Position.folderStub + currentGameState.SessionData.ClassPosition), abstractEvent: this, priority: 10));
                     }
                 } 
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played2mins && timeLeft / 60 < 2 && timeLeft / 60 > 1.9)
@@ -207,7 +207,7 @@ namespace CrewChiefV4.Events
                     played20mins = true;
                     playedHalfWayHome = true;
                     audioPlayer.suspendPearlsOfWisdom();
-                    audioPlayer.playMessage(new QueuedMessage(folder2mins, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage(folder2mins, 15, abstractEvent: this, priority: 10));
                 } if (currentGameState.SessionData.SessionRunningTime > 60 && !played5mins && timeLeft / 60 < 5 && timeLeft / 60 > 4.9)
                 {
                     played5mins = true;
@@ -218,16 +218,16 @@ namespace CrewChiefV4.Events
                     if (currentGameState.SessionData.SessionType == SessionType.Race && currentGameState.SessionData.ClassPosition == 1)
                     {
                         // don't add a pearl here - the audio clip already contains encouragement
-                        audioPlayer.playMessage(new QueuedMessage(folder5minsLeading, 0, this), pearlType, 0, 5);
+                        audioPlayer.playMessage(new QueuedMessage(folder5minsLeading, 20, abstractEvent: this, priority: 5), pearlType, 0);
                     }
                     else if (currentGameState.SessionData.SessionType == SessionType.Race && currentGameState.SessionData.ClassPosition < 4)
                     {
                         // don't add a pearl here - the audio clip already contains encouragement
-                        audioPlayer.playMessage(new QueuedMessage(folder5minsPodium, 0, this), pearlType, 0, 5);
+                        audioPlayer.playMessage(new QueuedMessage(folder5minsPodium, 20, abstractEvent: this, priority: 5), pearlType, 0);
                     }
                     else
                     {
-                        audioPlayer.playMessage(new QueuedMessage(folder5mins, 0, this), pearlType, 0.7, 5);
+                        audioPlayer.playMessage(new QueuedMessage(folder5mins, 20, abstractEvent: this, priority: 5), pearlType, 0.7);
                     }
                 }
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played10mins && timeLeft / 60 < 10 && timeLeft / 60 > 9.9)
@@ -235,25 +235,25 @@ namespace CrewChiefV4.Events
                     played10mins = true;
                     played15mins = true;
                     played20mins = true;
-                    audioPlayer.playMessage(new QueuedMessage(folder10mins, 0, this), pearlType, 0.7, 3);
+                    audioPlayer.playMessage(new QueuedMessage(folder10mins, 20, abstractEvent: this, priority: 3), pearlType, 0.7);
                 }
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played15mins && timeLeft / 60 < 15 && timeLeft / 60 > 14.9)
                 {
                     played15mins = true;
                     played20mins = true;
-                    audioPlayer.playMessage(new QueuedMessage(folder15mins, 0, this), pearlType, 0.7, 3);
+                    audioPlayer.playMessage(new QueuedMessage(folder15mins, 20, abstractEvent: this, priority: 3), pearlType, 0.7);
                 }
                 if (currentGameState.SessionData.SessionRunningTime > 60 && !played20mins && timeLeft / 60 < 20 && timeLeft / 60 > 19.9)
                 {
                     played20mins = true;
-                    audioPlayer.playMessage(new QueuedMessage(folder20mins, 0, this), pearlType, 0.7, 3);
+                    audioPlayer.playMessage(new QueuedMessage(folder20mins, 20, abstractEvent: this, priority: 3), pearlType, 0.7);
                 }
                 else if (currentGameState.SessionData.SessionType == SessionType.Race &&
                     currentGameState.SessionData.SessionRunningTime > 60 && !playedHalfWayHome && timeLeft > 0 && timeLeft < halfTime)
                 {
                     // this one sounds weird in practice and qual sessions, so skip it
                     playedHalfWayHome = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderHalfWayHome, 0, this), pearlType, 0.7, 3);
+                    audioPlayer.playMessage(new QueuedMessage(folderHalfWayHome, 20, abstractEvent: this, priority: 3), pearlType, 0.7);
                 }
             }
         }
@@ -265,51 +265,51 @@ namespace CrewChiefV4.Events
                 if (leaderHasFinishedRace)
                 {
                     Console.WriteLine("Playing last lap message, timeleft = " + timeLeft);
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderThisIsTheLastLap, 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderThisIsTheLastLap, 0));                    
                 }
                 if (timeLeft >= 120)
                 {
                     int minutesLeft = (int)Math.Round(timeLeft / 60f);
-                    audioPlayer.playMessageImmediately(new QueuedMessage("RaceTime/time_remaining",
-                        MessageContents(TimeSpanWrapper.FromMinutes(minutesLeft, Precision.MINUTES), folderRemaining), 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage("RaceTime/time_remaining", 0,
+                        messageFragments: MessageContents(TimeSpanWrapper.FromMinutes(minutesLeft, Precision.MINUTES), folderRemaining)));                    
                 }
                 else if (timeLeft >= 60)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderOneMinuteRemaining, 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderOneMinuteRemaining, 0));                    
                 }
                 else if (timeLeft <= 0)
                 {
                     if (addExtraLap && !startedExtraLap)
                     {
                         Console.WriteLine("Playing extra lap one more lap message, timeleft = " + timeLeft);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderOneLapAfterThisOne, 0, null));                        
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderOneLapAfterThisOne, 0));                        
                     }
                     else 
                     {
                         Console.WriteLine("Playing last lap message, timeleft = " + timeLeft);
-                        audioPlayer.playMessageImmediately(new QueuedMessage(folderThisIsTheLastLap, 0, null));                        
+                        audioPlayer.playMessageImmediately(new QueuedMessage(folderThisIsTheLastLap, 0));                        
                     }                   
                 }
                 else if (timeLeft < 60)
                 {
                     Console.WriteLine("Playing less than a minute message, timeleft = " + timeLeft);
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderLessThanOneMinute, 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderLessThanOneMinute, 0));                    
                 }
             }
             else
             {
                 if (lapsLeft > 2)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("RaceTime/laps_remaining",
-                        MessageContents(lapsLeft, folderLapsLeft), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("RaceTime/laps_remaining", 0,
+                        messageFragments: MessageContents(lapsLeft, folderLapsLeft)));
                 }
                 else if (lapsLeft == 2)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderOneLapAfterThisOne, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderOneLapAfterThisOne, 0));
                 }
                 else if (lapsLeft == 1)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(folderThisIsTheLastLap, 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage(folderThisIsTheLastLap, 0));                    
                 }
             }     
         }

--- a/CrewChiefV4/Events/SessionEndMessages.cs
+++ b/CrewChiefV4/Events/SessionEndMessages.cs
@@ -112,24 +112,24 @@ namespace CrewChiefV4.Events
                     }
                     if (!playedRant)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                            Penalties.folderDisqualified), 0, null), 10);
+                        audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0,
+                            messageFragments: AbstractEvent.MessageContents(Penalties.folderDisqualified), priority: 10));
                     }                    
                 }
                 else if (isDNF)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier,
-                        AbstractEvent.MessageContents(folderFinishedRaceLast), 0, null), 10);
+                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0,
+                        messageFragments: AbstractEvent.MessageContents(folderFinishedRaceLast), priority: 10));
                 }
                 else if (position == 1)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                        folderWonRace), 0, null), 10);
+                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0,
+                        messageFragments: AbstractEvent.MessageContents(folderWonRace), priority: 10));
                 }
                 else if (position < 4)
                 {
-                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                        folderPodiumFinish), 0, null), 10);
+                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0,
+                        messageFragments: AbstractEvent.MessageContents(folderPodiumFinish), priority: 10));
                 }
                 else if (position >= 4 && !isLast)
                 {
@@ -139,8 +139,8 @@ namespace CrewChiefV4.Events
                          (startPosition <= 10 && position <= 6) ||
                          (startPosition - position >= 6)))
                     {
-                        audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                                Position.folderStub + position, folderGoodFinish), 0, null), 10);
+                        audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0, 
+                            messageFragments: AbstractEvent.MessageContents(Position.folderStub + position, folderGoodFinish), priority: 10));
                     }
                     else
                     {
@@ -154,8 +154,8 @@ namespace CrewChiefV4.Events
                         }
                         if (!playedRant)
                         {
-                            audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(
-                                Position.folderStub + position, folderFinishedRace), 0, null), 10);
+                            audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0,
+                                messageFragments: AbstractEvent.MessageContents(Position.folderStub + position, folderFinishedRace), priority: 10));
                         }
                     }
                 }
@@ -168,8 +168,8 @@ namespace CrewChiefV4.Events
                     }
                     if (!playedRant)
                     {
-                        audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier,
-                            AbstractEvent.MessageContents(folderFinishedRaceLast), 0, null), 10);
+                        audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0,
+                            messageFragments: AbstractEvent.MessageContents(folderFinishedRaceLast), priority: 10));
                     }
                 }
             }
@@ -181,8 +181,8 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, AbstractEvent.MessageContents(folderEndOfSession,
-                    Position.folderStub + position), 0, null), 10);
+                    audioPlayer.playMessage(new QueuedMessage(sessionEndMessageIdentifier, 0, 
+                        messageFragments: AbstractEvent.MessageContents(folderEndOfSession, Position.folderStub + position), priority: 10));
                 }
             }
         }

--- a/CrewChiefV4/Events/SmokeTest.cs
+++ b/CrewChiefV4/Events/SmokeTest.cs
@@ -73,14 +73,17 @@ namespace CrewChiefV4.Events
                 {
                     if (SoundCache.availableDriverNames.Contains(DriverNameHelper.getUsableDriverName(driverToTest.DriverRawName)))
                     {
-                        audioPlayer.playMessage(new QueuedMessage("gap_in_front" + index,
-                                        MessageContents(Timings.folderTheGapTo, driverToTest, Timings.folderAheadIsIncreasing,
+                        audioPlayer.playMessage(new QueuedMessage("gap_in_front" + index, 0,
+                                        messageFragments: MessageContents(Timings.folderTheGapTo, driverToTest, Timings.folderAheadIsIncreasing,
                                         TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
-                                        MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)), 0, this));
-                        audioPlayer.playMessage(new QueuedMessage("leader_pitting" + index,
-                            MessageContents(Opponents.folderTheLeader, driverToTest, Opponents.folderIsPitting), 0, this));
-                        audioPlayer.playMessage(new QueuedMessage("new_fastest_lap" + index, MessageContents(Opponents.folderNewFastestLapFor, driverToTest,
-                                            TimeSpan.FromSeconds(Utilities.random.NextDouble() * 100)), 0, this));
+                                        alternateMessageFragments: MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
+                                        abstractEvent: this));
+                        audioPlayer.playMessage(new QueuedMessage("leader_pitting" + index, 0,
+                                        messageFragments: MessageContents(Opponents.folderTheLeader, driverToTest, Opponents.folderIsPitting), 
+                                        abstractEvent: this));
+                        audioPlayer.playMessage(new QueuedMessage("new_fastest_lap" + index, 0,
+                                        messageFragments: MessageContents(Opponents.folderNewFastestLapFor, driverToTest, TimeSpan.FromSeconds(Utilities.random.NextDouble() * 100)),
+                                        abstractEvent: this));
                         index++;
                     }
                     else
@@ -111,13 +114,14 @@ namespace CrewChiefV4.Events
 
             if (AudioPlayer.folderChiefRadioCheck != null)
             {
-                audioPlayer.playSpotterMessage(new QueuedMessage(SMOKE_TEST, MessageContents(AudioPlayer.folderChiefRadioCheck), 0, null), false);
+                audioPlayer.playSpotterMessage(new QueuedMessage(SMOKE_TEST, 0, messageFragments: MessageContents(AudioPlayer.folderChiefRadioCheck)), false);
             }
             if (NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck != null
                 && !String.Equals(UserSettings.GetUserSettings().getString("spotter_name"), UserSettings.GetUserSettings().getString("chief_name"), StringComparison.InvariantCultureIgnoreCase))  // Don't play this if spotter and chief are the same person.
             {
                 Thread.Sleep(800);
-                audioPlayer.playSpotterMessage(new QueuedMessage(SMOKE_TEST_SPOTTER, MessageContents(NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck), 0, null), false);
+                audioPlayer.playSpotterMessage(new QueuedMessage(SMOKE_TEST_SPOTTER, 0,
+                    messageFragments: MessageContents(NoisyCartesianCoordinateSpotter.folderSpotterRadioCheck)), false);
             }
 
             PlaybackModerator.SetTracing(true /*enabled*/);
@@ -152,19 +156,22 @@ namespace CrewChiefV4.Events
                 {
                     for (int i = 0; i < 10; i++)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("int" + i, MessageContents(Utilities.random.Next(3100)), 0, this));
+                        audioPlayer.playMessage(new QueuedMessage("int" + i, 0, messageFragments: MessageContents(Utilities.random.Next(3100)), abstractEvent: this));
                     }
                     for (int i = 0; i < 10; i++)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("time" + i, MessageContents(TimeSpan.FromSeconds(Utilities.random.Next(4000) + ((float)Utilities.random.Next(9) / 10f))), 0, this));
+                        audioPlayer.playMessage(new QueuedMessage("time" + i, 0,
+                            messageFragments: MessageContents(TimeSpan.FromSeconds(Utilities.random.Next(4000) + ((float)Utilities.random.Next(9) / 10f))), abstractEvent: this));
                     }
                     for (int i = 0; i < 10; i++)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("time" + i, MessageContents(TimeSpan.FromSeconds(Utilities.random.Next(60) + ((float)Utilities.random.Next(9) / 10f))), 0, this));
+                        audioPlayer.playMessage(new QueuedMessage("time" + i, 0,
+                            messageFragments: MessageContents(TimeSpan.FromSeconds(Utilities.random.Next(60) + ((float)Utilities.random.Next(9) / 10f))), abstractEvent: this));
                     }
                     for (int i = 0; i < 5; i++)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("time" + i, MessageContents(TimeSpan.FromSeconds(Utilities.random.NextDouble())), 0, this));
+                        audioPlayer.playMessage(new QueuedMessage("time" + i, 0,
+                            messageFragments: MessageContents(TimeSpan.FromSeconds(Utilities.random.NextDouble())), abstractEvent: this));
                     }
                     break;
                 }
@@ -235,7 +242,8 @@ namespace CrewChiefV4.Events
                 {                    
                     String [] nextNessage = new String [foldersOrStuff.Length - iter];
                     Array.Copy(foldersOrStuff, iter, nextNessage, 0, foldersOrStuff.Length - iter);
-                    audioPlayer.playMessageImmediately(new QueuedMessage(messageName, fragments, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+                    audioPlayer.playMessageImmediately(new QueuedMessage(messageName, 0, messageFragments: fragments, abstractEvent: this, 
+                        metadata: new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0)));
                     messageNumber++;
                     return soundTestPlay(nextNessage, messageNumber);
                 }
@@ -296,7 +304,8 @@ namespace CrewChiefV4.Events
                 }
 
             }
-            audioPlayer.playMessageImmediately(new QueuedMessage(messageName, fragments, 0, this) { metadata = new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0) });
+            audioPlayer.playMessageImmediately(new QueuedMessage(messageName, 0, messageFragments: fragments, abstractEvent: this,
+                metadata: new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0)));
             return true;
         }
 
@@ -315,39 +324,42 @@ namespace CrewChiefV4.Events
                                         TimeSpan.FromSeconds((float)random.NextDouble() * 10)),
                                         MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)random.NextDouble() * 10)), 0, this));*/
 
-            audioPlayer.playMessage(new QueuedMessage("position/bad_start", 0, this));
+            audioPlayer.playMessage(new QueuedMessage("position/bad_start", 0, abstractEvent: this));
 
             Thread.Sleep(5000);
-            inTheMiddleMessage = new QueuedMessage("spotter/in_the_middle", 0, null);
+            inTheMiddleMessage = new QueuedMessage("spotter/in_the_middle", 0);
             inTheMiddleMessage.expiryTime = (DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond) + 2000;
             audioPlayer.playSpotterMessage(inTheMiddleMessage, true);
 
             return; 
-            inTheMiddleMessage = new QueuedMessage("spotter/car_right", 0, null);
+            inTheMiddleMessage = new QueuedMessage("spotter/car_right", 0);
             inTheMiddleMessage.expiryTime = (DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond) + 2000;
             audioPlayer.playSpotterMessage(inTheMiddleMessage, true);
 
-            audioPlayer.playMessage(new QueuedMessage("gap_in_front2",
-                                        MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
+            audioPlayer.playMessage(new QueuedMessage("gap_in_front2", 0,
+                                        messageFragments:  MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
                                         TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
-                                        MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)), 0, this));
+                                        alternateMessageFragments: MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
+                                        abstractEvent: this));
 
             
 
-            audioPlayer.playMessage(new QueuedMessage("gap_in_front4",
-                                        MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
+            audioPlayer.playMessage(new QueuedMessage("gap_in_front4", 0,
+                                        messageFragments: MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
                                         TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
-                                        MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)), 0, this));
+                                        alternateMessageFragments: MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
+                                        abstractEvent: this));
             Thread.Sleep(8000);
             inTheMiddleMessage = new QueuedMessage("spotter/car_right", 0, null);
             inTheMiddleMessage.expiryTime = (DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond) + 20000;
             audioPlayer.playSpotterMessage(inTheMiddleMessage, true);
 
             Thread.Sleep(2000);
-            audioPlayer.playMessage(new QueuedMessage("gap_in_front3",
-                                        MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
+            audioPlayer.playMessage(new QueuedMessage("gap_in_front3", 0, 
+                                        messageFragments: MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
                                         TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
-                                        MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)), 0, this));
+                                        alternateMessageFragments: MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
+                                        abstractEvent: this));
 
 
             Thread.Sleep(4000);
@@ -356,10 +368,11 @@ namespace CrewChiefV4.Events
             audioPlayer.playSpotterMessage(inTheMiddleMessage, true);
 
             Thread.Sleep(5000);
-            audioPlayer.playMessage(new QueuedMessage("gap_in_front4",
-                                        MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
+            audioPlayer.playMessage(new QueuedMessage("gap_in_front4", 0,
+                                        messageFragments: MessageContents(Timings.folderTheGapTo, makeTempDriver("7908jimmy6^&^", new List<string>()), Timings.folderAheadIsIncreasing,
                                         TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
-                                        MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)), 0, this));
+                                        alternateMessageFragments: MessageContents(Timings.folderGapInFrontIncreasing, TimeSpan.FromSeconds((float)Utilities.random.NextDouble() * 10)),
+                                        abstractEvent: this));
         }
 
         private void messageInterruptTest()
@@ -375,7 +388,7 @@ namespace CrewChiefV4.Events
             fragments.Add(MessageFragment.Opponent(makeTempDriver("bakus", rawDriverNames)));
             fragments.Add(MessageFragment.Text(Strategy.folderAnd));
             fragments.Add(MessageFragment.Opponent(makeTempDriver("fillingham", rawDriverNames)));
-            audioPlayer.playMessage(new QueuedMessage("check", fragments, 0, this));
+            audioPlayer.playMessage(new QueuedMessage("check", 0, messageFragments: fragments, abstractEvent: this));
             fragments = new List<MessageFragment>();
             fragments.Add(MessageFragment.Text(Strategy.folderClearTrackOnPitExit));
             fragments.Add(MessageFragment.Text(Strategy.folderWeShouldEmergeInPosition));
@@ -384,7 +397,7 @@ namespace CrewChiefV4.Events
             fragments.Add(MessageFragment.Opponent(makeTempDriver("bakus", rawDriverNames)));
             fragments.Add(MessageFragment.Text(Strategy.folderAnd));
             fragments.Add(MessageFragment.Opponent(makeTempDriver("fillingham", rawDriverNames)));
-            audioPlayer.playMessage(new QueuedMessage("check", fragments, 0, this));
+            audioPlayer.playMessage(new QueuedMessage("check", 0, messageFragments: fragments, abstractEvent: this));
             Thread.Sleep(2500);
             audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderEnableSpotter, 0, null));
 

--- a/CrewChiefV4/Events/SmokeTest.cs
+++ b/CrewChiefV4/Events/SmokeTest.cs
@@ -243,7 +243,7 @@ namespace CrewChiefV4.Events
                     String [] nextNessage = new String [foldersOrStuff.Length - iter];
                     Array.Copy(foldersOrStuff, iter, nextNessage, 0, foldersOrStuff.Length - iter);
                     audioPlayer.playMessageImmediately(new QueuedMessage(messageName, 0, messageFragments: fragments, abstractEvent: this, 
-                        metadata: new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0)));
+                        type: SoundType.IMPORTANT_MESSAGE, priority: 0));
                     messageNumber++;
                     return soundTestPlay(nextNessage, messageNumber);
                 }
@@ -305,7 +305,7 @@ namespace CrewChiefV4.Events
 
             }
             audioPlayer.playMessageImmediately(new QueuedMessage(messageName, 0, messageFragments: fragments, abstractEvent: this,
-                metadata: new SoundMetadata(SoundType.IMPORTANT_MESSAGE, 0)));
+                type: SoundType.IMPORTANT_MESSAGE, priority: 0));
             return true;
         }
 

--- a/CrewChiefV4/Events/Spotter.cs
+++ b/CrewChiefV4/Events/Spotter.cs
@@ -26,12 +26,12 @@ namespace CrewChiefV4.Events
         public void enableSpotter()
         {
             enabled = true;
-            audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderEnableSpotter, 0, null));
+            audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderEnableSpotter, 0));
         }
         public void disableSpotter()
         {
             enabled = false;
-            audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderDisableSpotter, 0, null));
+            audioPlayer.playMessageImmediately(new QueuedMessage(NoisyCartesianCoordinateSpotter.folderDisableSpotter, 0));
         }
 
         public void pause()

--- a/CrewChiefV4/Events/Strategy.cs
+++ b/CrewChiefV4/Events/Strategy.cs
@@ -209,10 +209,9 @@ namespace CrewChiefV4.Events
                     // only notify about this if we're in a practice session
                     if (currentGameState.SessionData.SessionType == SessionType.Practice)
                     {
-                        audioPlayer.playMessage(new QueuedMessage("pit_stop_cost_estimate",
-                            MessageContents(folderPitStopCostsUsAbout,
-                            TimeSpanWrapper.FromSeconds(playerTimeLostForStop, Precision.SECONDS)),
-                            0, this), 10);
+                        audioPlayer.playMessage(new QueuedMessage("pit_stop_cost_estimate", 0,
+                            messageFragments: MessageContents(folderPitStopCostsUsAbout, TimeSpanWrapper.FromSeconds(playerTimeLostForStop, Precision.SECONDS)),
+                            abstractEvent: this, priority: 10));
                     }
                     waitingForValidDataForBenchmark = false;
                 }
@@ -273,10 +272,10 @@ namespace CrewChiefV4.Events
                                 waitingForValidDataForBenchmark = false;
                                 setTimeLossFromBenchmark(currentGameState);
                                 Console.WriteLine("Practice pitstop has cost us " + playerTimeLostForStop + " seconds");
-                                audioPlayer.playMessage(new QueuedMessage("pit_stop_cost_estimate",
-                                    MessageContents(folderPitStopCostsUsAbout,
+                                audioPlayer.playMessage(new QueuedMessage("pit_stop_cost_estimate", 0,
+                                    messageFragments: MessageContents(folderPitStopCostsUsAbout,
                                     TimeSpanWrapper.FromSeconds(playerTimeLostForStop, Precision.SECONDS)),
-                                    0, this), 10);
+                                    abstractEvent: this, priority: 10));
                             }
                             else
                             {
@@ -313,8 +312,9 @@ namespace CrewChiefV4.Events
                                 {
                                     // this guy has just entered the pit and we predict he'll exit just in front of us
                                     Console.WriteLine("Opponent " + entry.Value.DriverRawName + " will exit the pit close in front of us");
-                                    audioPlayer.playMessage(new QueuedMessage("opponent_exiting_in_front", MessageContents(entry.Value,
-                                        folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustInFront), 0, this), 10);
+                                    audioPlayer.playMessage(new QueuedMessage("opponent_exiting_in_front", 10,
+                                        messageFragments: MessageContents(entry.Value, folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustInFront),
+                                        abstractEvent: this, priority: 10));
 
                                     // only allow one of these every 10 seconds. When an opponent crosses the start line he's 
                                     // removed from this set anyway
@@ -325,8 +325,9 @@ namespace CrewChiefV4.Events
                                 {
                                     // this guy has just entered the pit and we predict he'll exit just behind us
                                     Console.WriteLine("Opponent " + entry.Value.DriverRawName + " will exit the pit close behind us");
-                                    audioPlayer.playMessage(new QueuedMessage("opponent_exiting_behind", MessageContents(entry.Value,
-                                        folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustBehind), 0, this), 10);
+                                    audioPlayer.playMessage(new QueuedMessage("opponent_exiting_behind", 10,
+                                        messageFragments: MessageContents(entry.Value, folderIsPittingFromPosition, entry.Value.ClassPosition, folderHeWillComeOutJustBehind),
+                                        abstractEvent: this, priority: 10));
                                     // only allow one of these every 10 seconds. When an opponent crosses the start line he's 
                                     // removed from this set anyway
                                     nextOpponentPitExitWarningDue = currentGameState.Now.AddSeconds(10);

--- a/CrewChiefV4/Events/Strategy.cs
+++ b/CrewChiefV4/Events/Strategy.cs
@@ -1086,16 +1086,16 @@ namespace CrewChiefV4.Events
             {
                 if (pitPositionEstimatesRequested)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("pit_stop_position_prediction", fragments, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("pit_stop_position_prediction", 0, messageFragments: fragments));
                 }
                 else
                 {
-                    audioPlayer.playMessage(new QueuedMessage("pit_stop_position_prediction", fragments, 0, this), 10);
+                    audioPlayer.playMessage(new QueuedMessage("pit_stop_position_prediction", 0, messageFragments: fragments, abstractEvent: this, priority: 10));
                 }
             }
             else if (pitPositionEstimatesRequested)
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
             }
         }
 

--- a/CrewChiefV4/Events/Timings.cs
+++ b/CrewChiefV4/Events/Timings.cs
@@ -242,7 +242,7 @@ namespace CrewChiefV4.Events
                 currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark != null)
             {
                 // mid-point it true for only 1 tick so this should be safe
-                audioPlayer.playMessage(new QueuedMessage("corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark, 0, this), 10);
+                audioPlayer.playMessage(new QueuedMessage("corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark, 2, abstractEvent: this, priority: 10));
             }
             if (GameStateData.onManualFormationLap)
             {
@@ -339,7 +339,8 @@ namespace CrewChiefV4.Events
                                     sectorsUntilNextCloseCarAheadReport = adjustForMidLapPreference(currentGameState.SessionData.SectorNumber,
                                         Utilities.random.Next(closeAheadMinSectorWait, closeAheadMaxSectorWait));
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderBeingHeldUp, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderBeingHeldUp, 3, abstractEvent: this,
+                                    validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 10));
                                 OpponentData opponent = currentGameState.getOpponentAtClassPosition(currentGameState.SessionData.ClassPosition - 1, currentGameState.carClass);
                                 if (opponent != null)
                                 {
@@ -353,7 +354,8 @@ namespace CrewChiefV4.Events
                                         {
                                             // either we're faster on entry or faster through
                                             String attackFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsSlowerThroughCorner : folderHeIsSlowerEnteringCorner;
-                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
+                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", 5,
+                                                messageFragments: MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), abstractEvent: this, priority: 5));
                                             trackLandmarkAttackDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                         }
                                     }
@@ -390,7 +392,8 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", 5, delayedMessageEvent: delayedMessageEvent, abstractEvent: this, 
+                                            validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 5));
                                     }
                                 }
                                 else if (gapInFrontStatus == GapStatus.DECREASING)
@@ -405,7 +408,8 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", 5, delayedMessageEvent: delayedMessageEvent, abstractEvent: this,
+                                            validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 5));
 
                                         DateTime lastTimeDriverNameUsed = DateTime.MinValue;
                                         if (!trackLandmarkAttackDriverNamesUsed.TryGetValue(opponent.DriverRawName, out lastTimeDriverNameUsed) ||
@@ -417,7 +421,8 @@ namespace CrewChiefV4.Events
                                             {
                                                 // either we're faster on entry or faster through
                                                 String attackFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsSlowerThroughCorner : folderHeIsSlowerEnteringCorner;
-                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
+                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_attack_in", 5,
+                                                    messageFragments: MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), abstractEvent: this, priority: 5));
                                                 trackLandmarkAttackDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                             }
                                         }
@@ -435,7 +440,8 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_in_front", 5, delayedMessageEvent: delayedMessageEvent, abstractEvent: this, 
+                                            validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 5));
                                     }
                                 }
                             }
@@ -459,7 +465,8 @@ namespace CrewChiefV4.Events
                                     sectorsUntilNextCloseCarBehindReport = adjustForMidLapPreference(currentGameState.SessionData.SectorNumber,
                                         Utilities.random.Next(closeBehindMinSectorWait, closeBehindMaxSectorWait));
                                 }
-                                audioPlayer.playMessage(new QueuedMessage(folderBeingPressured, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 10);
+                                audioPlayer.playMessage(new QueuedMessage(folderBeingPressured, 3, abstractEvent: this, 
+                                    validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 10));
                                 OpponentData opponent = currentGameState.getOpponentAtClassPosition(currentGameState.SessionData.ClassPosition + 1, currentGameState.carClass);
                                 if (opponent != null)
                                 {
@@ -473,7 +480,8 @@ namespace CrewChiefV4.Events
                                         {
                                             // either we're slower on entry or slower through
                                             String defendFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsFasterThroughCorner : folderHeIsFasterEnteringCorner;
-                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
+                                            audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", 5,
+                                                messageFragments: MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), abstractEvent: this, priority: 5));
                                             trackLandmarkDefendDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                         }
                                     }
@@ -510,7 +518,8 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", 5, delayedMessageEvent: delayedMessageEvent, abstractEvent: this,
+                                            validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } },priority: 5));
                                     }
                                 }
                                 else if (gapBehindStatus == GapStatus.DECREASING)
@@ -525,7 +534,8 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 10);
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", 5, delayedMessageEvent: delayedMessageEvent, abstractEvent: this,
+                                            validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 10));
 
                                         DateTime lastTimeDriverNameUsed = DateTime.MinValue;
                                         if (!trackLandmarkDefendDriverNamesUsed.TryGetValue(opponent.DriverRawName, out lastTimeDriverNameUsed) ||
@@ -537,7 +547,8 @@ namespace CrewChiefV4.Events
                                             {
                                                 // either we're slower on entry or slower through
                                                 String defendFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsFasterThroughCorner : folderHeIsFasterEnteringCorner;
-                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, this), 5);
+                                                audioPlayer.playMessage(new QueuedMessage("Timings/corner_to_defend_in", 5,
+                                                    messageFragments: MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), abstractEvent: this, priority: 5));
                                                 trackLandmarkDefendDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                                             }
                                         }
@@ -555,7 +566,8 @@ namespace CrewChiefV4.Events
                                         DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }), 5);
+                                        audioPlayer.playMessage(new QueuedMessage("Timings/gap_behind", 5, delayedMessageEvent: delayedMessageEvent, abstractEvent: this,
+                                            validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 5));
                                     }
                                 }
                             }
@@ -579,9 +591,10 @@ namespace CrewChiefV4.Events
                                 DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             true, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                QueuedMessage message = new QueuedMessage("Timings/gap_ahead", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } });
+                                QueuedMessage message = new QueuedMessage("Timings/gap_ahead", 0, delayedMessageEvent: delayedMessageEvent, abstractEvent: this,
+                                    validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 10);
                                 message.playEvenWhenSilenced = true;
-                                audioPlayer.playMessage(message, 10);
+                                audioPlayer.playMessage(message);
                             }
                         }
                     }
@@ -603,9 +616,10 @@ namespace CrewChiefV4.Events
                                 DelayedMessageEvent delayedMessageEvent = new DelayedMessageEvent("resolveGapAmount", new Object[] {
                                             false, primaryPartialMessageContents, primaryGapIndex, alternatePartialMessageContents, alternateGapIndex }, this);
 
-                                QueuedMessage message = new QueuedMessage("Timings/gap_behind", delayedMessageEvent, 0, this, new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } });
+                                QueuedMessage message = new QueuedMessage("Timings/gap_behind", 0, delayedMessageEvent: delayedMessageEvent, abstractEvent: this,
+                                    validationData: new Dictionary<string, object> { { "position", currentGameState.SessionData.ClassPosition } }, priority: 10);
                                 message.playEvenWhenSilenced = true;
-                                audioPlayer.playMessage(message, 10);
+                                audioPlayer.playMessage(message);
                             }
                         }
                     }
@@ -659,16 +673,16 @@ namespace CrewChiefV4.Events
                 {
                     if (currentGapBehind > 2)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_behind",
-                                MessageContents(folderGapBehindIsNow, TimeSpanWrapper.FromMilliseconds(currentGapBehind * 1000, Precision.AUTO_GAPS)), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_behind", 0,
+                                messageFragments: MessageContents(folderGapBehindIsNow, TimeSpanWrapper.FromMilliseconds(currentGapBehind * 1000, Precision.AUTO_GAPS))));
                     }
                 }
                 else
                 {
                     if (currentGapInFront > 2)
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_in_front",
-                            MessageContents(folderGapInFrontIsNow, TimeSpanWrapper.FromMilliseconds(currentGapInFront * 1000, Precision.AUTO_GAPS)), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_in_front", 0,
+                                messageFragments: MessageContents(folderGapInFrontIsNow, TimeSpanWrapper.FromMilliseconds(currentGapInFront * 1000, Precision.AUTO_GAPS))));
                     }
                 }
             }
@@ -690,8 +704,8 @@ namespace CrewChiefV4.Events
                                 haveData = true;
                                 // either we're faster on entry or faster through
                                 String attackFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsSlowerThroughCorner : folderHeIsSlowerEnteringCorner;
-                                audioPlayer.playMessageImmediately(new QueuedMessage("Timings/corner_to_attack_in",
-                                    MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, null));
+                                audioPlayer.playMessageImmediately(new QueuedMessage("Timings/corner_to_attack_in", 0,
+                                    messageFragments: MessageContents(Pause(200), attackFolder, "corners/" + landmarkAndDeltaType.landmarkName)));
                                 trackLandmarkAttackDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                             }
                         }
@@ -712,8 +726,8 @@ namespace CrewChiefV4.Events
                                 haveData = true;
                                 // either we're slower on entry or slower through
                                 String defendFolder = landmarkAndDeltaType.deltaType == TrackLandmarksTiming.DeltaType.Time ? folderHeIsFasterThroughCorner : folderHeIsFasterEnteringCorner;
-                                audioPlayer.playMessageImmediately(new QueuedMessage("Timings/corner_to_defend_in",
-                                    MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName), 0, null));
+                                audioPlayer.playMessageImmediately(new QueuedMessage("Timings/corner_to_defend_in", 0,
+                                    messageFragments: MessageContents(Pause(200), defendFolder, "corners/" + landmarkAndDeltaType.landmarkName)));
                                 trackLandmarkDefendDriverNamesUsed[opponent.DriverRawName] = currentGameState.Now;
                             }
                         }
@@ -728,8 +742,8 @@ namespace CrewChiefV4.Events
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_in_front",
-                            MessageContents(TimeSpanWrapper.FromMilliseconds(currentGapInFront * 1000, Precision.AUTO_GAPS)), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_in_front", 0,
+                                messageFragments: MessageContents(TimeSpanWrapper.FromMilliseconds(currentGapInFront * 1000, Precision.AUTO_GAPS))));
                         haveData = true;
                     }
                 }
@@ -743,8 +757,8 @@ namespace CrewChiefV4.Events
                     }
                     else
                     {
-                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_behind",
-                            MessageContents(TimeSpanWrapper.FromMilliseconds(currentGapBehind * 1000, Precision.AUTO_GAPS)), 0, null));
+                        audioPlayer.playMessageImmediately(new QueuedMessage("Timings/gap_behind", 0,
+                                messageFragments: MessageContents(TimeSpanWrapper.FromMilliseconds(currentGapBehind * 1000, Precision.AUTO_GAPS))));
                         haveData = true;
                     }
                 }

--- a/CrewChiefV4/Events/TyreMonitor.cs
+++ b/CrewChiefV4/Events/TyreMonitor.cs
@@ -584,23 +584,28 @@ namespace CrewChiefV4.Events
                                 // not moaned about this for a while, so moan away
                                 cornerLockWarningsPlayed[currentCornerName] = currentGameState.Now;
                                 Console.WriteLine("Locking " + cornerLocking + " into " + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark);
+                                int delay = Utilities.random.Next(4, 8);
                                 switch (cornerLocking)
                                 {
                                     case WheelsLockedEnum.FRONTS:
-                                        audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingFrontsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
+                                        audioPlayer.playMessage(new QueuedMessage("corner_locking", delay + 10, secondsDelay: delay,
+                                            messageFragments: MessageContents(folderLockingFrontsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), 
+                                            abstractEvent: this, priority: 0));
                                         break;
                                     case WheelsLockedEnum.LEFT_FRONT:
-                                        audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingLeftFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
+                                        audioPlayer.playMessage(new QueuedMessage("corner_locking", delay + 10, secondsDelay: delay,
+                                            messageFragments: MessageContents(folderLockingLeftFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark),
+                                            abstractEvent: this, priority: 0));
                                         break;
                                     case WheelsLockedEnum.RIGHT_FRONT:
-                                        audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingRightFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
+                                        audioPlayer.playMessage(new QueuedMessage("corner_locking", delay + 10, secondsDelay: delay,
+                                            messageFragments: MessageContents(folderLockingRightFrontForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark),
+                                            abstractEvent: this, priority: 0));
                                         break;
                                     case WheelsLockedEnum.REARS:
-                                        audioPlayer.playMessage(new QueuedMessage("corner_locking",
-                                            MessageContents(folderLockingRearsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark), Utilities.random.Next(4, 8), this), 0);
+                                        audioPlayer.playMessage(new QueuedMessage("corner_locking", delay + 10, secondsDelay: delay,
+                                            messageFragments: MessageContents(folderLockingRearsForCornerWarning, "corners/" + currentGameState.SessionData.trackLandmarksTiming.atMidPointOfLandmark),
+                                            abstractEvent: this, priority: 0));
                                         break;
                                     default:
                                         break;
@@ -634,52 +639,53 @@ namespace CrewChiefV4.Events
                             float rightFrontCornerSpecificWheelSpinTime = timeRightFrontIsSpinningForLap - rightFrontExitStartWheelSpinTime;
                             float leftRearCornerSpecificWheelSpinTime = timeLeftRearIsSpinningForLap - leftRearExitStartWheelSpinTime;
                             float rightRearCornerSpecificWheelSpinTime = timeRightRearIsSpinningForLap - rightRearExitStartWheelSpinTime;
+                            int delay = Utilities.random.Next(4, 8);
                             if (!currentGameState.carClass.allMembersAreRWD && 
                                 leftFrontCornerSpecificWheelSpinTime > cornerExitSpinningThreshold && rightFrontCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning fronts out of " + currentCornerName);
-                                audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningFrontsForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("corner_spinning", delay + 10, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderSpinningFrontsForCornerWarning, "corners/" + currentCornerName), abstractEvent: this, priority: 0));
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (!currentGameState.carClass.allMembersAreFWD &&
                                 leftRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold && rightRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning rears out of " + currentCornerName);
-                                audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningRearsForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("corner_spinning", delay + 10, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderSpinningRearsForCornerWarning, "corners/" + currentCornerName), abstractEvent: this, priority: 0));
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (!currentGameState.carClass.allMembersAreRWD && 
                                 leftFrontCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning left front out of " + currentCornerName);
-                                audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningLeftFrontForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("corner_spinning", delay + 10, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderSpinningLeftFrontForCornerWarning, "corners/" + currentCornerName), abstractEvent: this, priority: 0));
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (!currentGameState.carClass.allMembersAreRWD && 
                                 rightFrontCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning right front out of " + currentCornerName);
-                                audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningRightFrontForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("corner_spinning", delay + 10, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderSpinningRightFrontForCornerWarning, "corners/" + currentCornerName), abstractEvent: this, priority: 0));
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (!currentGameState.carClass.allMembersAreFWD &&
                                 leftRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning left rear out of " + currentCornerName);
-                                audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningLeftRearForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("corner_spinning", delay + 10, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderSpinningLeftRearForCornerWarning, "corners/" + currentCornerName), abstractEvent: this, priority: 0));
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                             else if (!currentGameState.carClass.allMembersAreFWD &&
                                 rightRearCornerSpecificWheelSpinTime > cornerExitSpinningThreshold)
                             {
                                 Console.WriteLine("Spinning right rear out of " + currentCornerName);
-                                audioPlayer.playMessage(new QueuedMessage("corner_spinning",
-                                    MessageContents(folderSpinningRightRearForCornerWarning, "corners/" + currentCornerName), Utilities.random.Next(4, 8), this), 0);
+                                audioPlayer.playMessage(new QueuedMessage("corner_spinning", delay + 10, secondsDelay: delay,
+                                    messageFragments: MessageContents(folderSpinningRightRearForCornerWarning, "corners/" + currentCornerName), abstractEvent: this, priority: 0));
                                 cornerSpinningWarningsPlayed[currentCornerName] = currentGameState.Now;
                             }
                         }
@@ -879,12 +885,12 @@ namespace CrewChiefV4.Events
             {
                 if (playImmediately)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("tyre_temps", messageContents, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("tyre_temps", 0, messageFragments: messageContents));
                 }
                 else if (lastTyreTempMessage == null || !messagesHaveSameContent(lastTyreTempMessage, messageContents))
                 {
                     Console.WriteLine("Tyre temp warning, temps : "+ String.Join(", ", messageContents));
-                    audioPlayer.playMessage(new QueuedMessage("tyre_temps", messageContents, Utilities.random.Next(0, 10), this), 5);
+                    audioPlayer.playMessage(new QueuedMessage("tyre_temps", 0, messageContents, secondsDelay: Utilities.random.Next(0, 10), abstractEvent: this, priority: 5));
                 }
             }
             lastTyreTempMessage = messageContents;
@@ -933,11 +939,11 @@ namespace CrewChiefV4.Events
             {
                 if (playImmediately)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("brake_temps", messageContents, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("brake_temps", 0, messageFragments: messageContents));
                 }
                 else if (lastBrakeTempMessage == null || !messagesHaveSameContent(lastBrakeTempMessage, messageContents))
                 {
-                    audioPlayer.playMessage(new QueuedMessage("brake_temps", messageContents, Utilities.random.Next(0, 10), this), 5);
+                    audioPlayer.playMessage(new QueuedMessage("brake_temps", 0, messageFragments: messageContents, secondsDelay: Utilities.random.Next(0, 10), abstractEvent: this, priority: 5));
                 }
             }
             lastBrakeTempMessage = messageContents;
@@ -964,17 +970,17 @@ namespace CrewChiefV4.Events
                     audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderStandBy, 0, null));
                     int secondsDelay = Math.Max(5, Utilities.random.Next(11));
                     audioPlayer.pauseQueue(secondsDelay);
-                    audioPlayer.playDelayedImmediateMessage(new QueuedMessage("tyre_condition", messageContents, secondsDelay, null));
+                    audioPlayer.playDelayedImmediateMessage(new QueuedMessage("tyre_condition", 0, messageFragments: messageContents, secondsDelay: secondsDelay));
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("tyre_condition", messageContents, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("tyre_condition", 0, messageFragments: messageContents));
                 }
             }
             else if (playEvenIfUnchanged || 
                 (lastTyreConditionMessage != null && !messagesHaveSameContent(lastTyreConditionMessage, messageContents) && !wearIsGood))
             {
-                audioPlayer.playMessage(new QueuedMessage("tyre_condition", messageContents, Utilities.random.Next(0, 10), this), 5);
+                audioPlayer.playMessage(new QueuedMessage("tyre_condition", 0, messageFragments: messageContents, secondsDelay: Utilities.random.Next(0, 10), abstractEvent: this, priority: 5));
             }
             lastTyreConditionMessage = messageContents;
         }
@@ -989,14 +995,14 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("minutes_on_current_tyres", MessageContents(folderMinutesOnCurrentTyresIntro, 
-                        minutesRemainingOnTheseTyres, folderMinutesOnCurrentTyresOutro), 0,  null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("minutes_on_current_tyres", 0, 
+                        messageFragments: MessageContents(folderMinutesOnCurrentTyresIntro, minutesRemainingOnTheseTyres, folderMinutesOnCurrentTyresOutro)));
                 }
             }
             else if (minutesRemainingOnTheseTyres > 1 && minutesRemainingOnTheseTyres <= 4 + (timeInSession - timeElapsed) / 60)
             {
-                 audioPlayer.playMessage(new QueuedMessage("minutes_on_current_tyres", MessageContents(folderMinutesOnCurrentTyresIntro, 
-                     minutesRemainingOnTheseTyres, folderMinutesOnCurrentTyresOutro), 0, this), 5);                
+                 audioPlayer.playMessage(new QueuedMessage("minutes_on_current_tyres", 0, 
+                     messageFragments: MessageContents(folderMinutesOnCurrentTyresIntro, minutesRemainingOnTheseTyres, folderMinutesOnCurrentTyresOutro), abstractEvent: this, priority: 5));                
             }
         }
 
@@ -1010,14 +1016,14 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("laps_on_current_tyres", MessageContents(folderLapsOnCurrentTyresIntro,
-                        lapsRemainingOnTheseTyres, folderLapsOnCurrentTyresOutro), 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage("laps_on_current_tyres", 0,
+                        messageFragments: MessageContents(folderLapsOnCurrentTyresIntro, lapsRemainingOnTheseTyres, folderLapsOnCurrentTyresOutro)));
                 }
             }
             else if (lapsRemainingOnTheseTyres > 1 && lapsRemainingOnTheseTyres <= 2 + lapsInSession - completedLaps)
             {
-                audioPlayer.playMessage(new QueuedMessage("laps_on_current_tyres", MessageContents(folderLapsOnCurrentTyresIntro, 
-                        lapsRemainingOnTheseTyres, folderLapsOnCurrentTyresOutro), 0, this), 5);              
+                audioPlayer.playMessage(new QueuedMessage("laps_on_current_tyres", 0, 
+                    messageFragments: MessageContents(folderLapsOnCurrentTyresIntro, lapsRemainingOnTheseTyres, folderLapsOnCurrentTyresOutro), abstractEvent: this, priority: 5));              
             }
         }
 
@@ -1148,12 +1154,13 @@ namespace CrewChiefV4.Events
         {
             if (leftFrontTyreTemp == 0 && rightFrontTyreTemp == 0 && leftRearTyreTemp == 0 && rightRearTyreTemp == 0)
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
             }
             else
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage("tyre_temps", MessageContents(folderLeftFront, convertTemp(leftFrontTyreTemp), 
-                    folderRightFront, convertTemp(rightFrontTyreTemp), folderLeftRear, convertTemp(leftRearTyreTemp), folderRightRear, convertTemp(rightRearTyreTemp), getTempUnit()), 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage("tyre_temps", 0, 
+                    messageFragments:  MessageContents(folderLeftFront, convertTemp(leftFrontTyreTemp), folderRightFront, convertTemp(rightFrontTyreTemp),
+                                                       folderLeftRear, convertTemp(leftRearTyreTemp), folderRightRear, convertTemp(rightRearTyreTemp), getTempUnit())));
             }
             
         }
@@ -1162,12 +1169,13 @@ namespace CrewChiefV4.Events
         {
             if (leftFrontBrakeTemp == 0 && rightFrontBrakeTemp == 0 && leftRearBrakeTemp == 0 && rightRearBrakeTemp == 0)
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
             }
             else
             {
-                audioPlayer.playMessageImmediately(new QueuedMessage("brake_temps", MessageContents(folderLeftFront, convertTemp(leftFrontBrakeTemp, 10), 
-                    folderRightFront, convertTemp(rightFrontBrakeTemp, 10), folderLeftRear, convertTemp(leftRearBrakeTemp, 10), folderRightRear, convertTemp(rightRearBrakeTemp, 10), getTempUnit()), 0, null));
+                audioPlayer.playMessageImmediately(new QueuedMessage("brake_temps", 0,
+                    messageFragments: MessageContents(folderLeftFront, convertTemp(leftFrontBrakeTemp, 10), folderRightFront, convertTemp(rightFrontBrakeTemp, 10), 
+                                                      folderLeftRear, convertTemp(leftRearBrakeTemp, 10), folderRightRear, convertTemp(rightRearBrakeTemp, 10), getTempUnit())));
             }
             
         }
@@ -1182,7 +1190,7 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));                        
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));                        
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHAT_ARE_MY_TYRE_TEMPS))
@@ -1197,7 +1205,7 @@ namespace CrewChiefV4.Events
                 }
                 else
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHAT_ARE_MY_BRAKE_TEMPS))
@@ -1213,7 +1221,7 @@ namespace CrewChiefV4.Events
                 }
                 else if (!forStatusReport)
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0, null));                    
+                    audioPlayer.playMessageImmediately(new QueuedMessage(AudioPlayer.folderNoData, 0));                    
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.WHAT_ARE_THE_RELATIVE_TYRE_PERFORMANCES))
@@ -1221,10 +1229,10 @@ namespace CrewChiefV4.Events
                 List<TyrePerformanceContainer> tyrePerformances = getRelativeTyrePerformance();
                 foreach (TyrePerformanceContainer tyrePeformance in tyrePerformances) 
                 {
-                    audioPlayer.playMessageImmediately(new QueuedMessage("tyre_comparison_" + tyrePeformance.type1 + "-" + tyrePeformance.type2, 
-                        MessageContents(getFolderForTyreType(tyrePeformance.type1), folderAreAbout, 
+                    audioPlayer.playMessageImmediately(new QueuedMessage("tyre_comparison_" + tyrePeformance.type1 + "-" + tyrePeformance.type2, 0, 
+                        messageFragments: MessageContents(getFolderForTyreType(tyrePeformance.type1), folderAreAbout, 
                                         TimeSpanWrapper.FromSeconds(tyrePeformance.bestLapDelta, Precision.AUTO_GAPS),
-                                        folderFasterThan, getFolderForTyreType(tyrePeformance.type2)), 0, null));
+                                        folderFasterThan, getFolderForTyreType(tyrePeformance.type2))));
                 }
             }
             else if (SpeechRecogniser.ResultContains(voiceMessage, SpeechRecogniser.CAR_STATUS) ||
@@ -1727,13 +1735,13 @@ namespace CrewChiefV4.Events
                     if (timeRightFrontIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of left front locking, some right front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just left front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftFrontForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftFrontForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
@@ -1743,20 +1751,20 @@ namespace CrewChiefV4.Events
                     if (timeLeftFrontIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of right front locking, some left front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingFrontsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just right front locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightFrontForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightFrontForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
                 else if (isFWD && timeBothRearsAreLockedForLap > totalLockupThresholdForNextLap)
                 {
                     warnedOnLockingForLap = true;
-                    audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this), 0);
+                    audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                     playedMessage = true;
                 }
                 else if (!isFWD && timeLeftRearIsLockedForLap > totalLockupThresholdForNextLap)
@@ -1765,13 +1773,13 @@ namespace CrewChiefV4.Events
                     if (timeRightRearIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of left rear locking, some right rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just left rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftRearForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingLeftRearForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
@@ -1781,13 +1789,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftRearIsLockedForLap > totalLockupThresholdForNextLap / 2)
                     {
                         // lots of right rear locking, some left rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRearsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just right rear locking
-                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightRearForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderLockingRightRearForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
@@ -1807,13 +1815,13 @@ namespace CrewChiefV4.Events
                     if (timeRightFrontIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of left front spinning, some right front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just left front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftFrontForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftFrontForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
@@ -1823,13 +1831,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftFrontIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of right front spinning, some left front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningFrontsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just right front spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightFrontForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightFrontForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
@@ -1839,13 +1847,13 @@ namespace CrewChiefV4.Events
                     if (timeRightRearIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of left rear spinning, some right rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just left rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftRearForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningLeftRearForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }
@@ -1855,13 +1863,13 @@ namespace CrewChiefV4.Events
                     if (timeLeftRearIsSpinningForLap > totalWheelspinThresholdForNextLap / 2)
                     {
                         // lots of right rear spinning, some left rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRearsForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                     else
                     {
                         // just right rear spinning
-                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightRearForLapWarning, messageDelay, this), 0);
+                        audioPlayer.playMessage(new QueuedMessage(folderSpinningRightRearForLapWarning, messageDelay + 6, secondsDelay: messageDelay, abstractEvent: this, priority: 0));
                         playedMessage = true;
                     }
                 }

--- a/CrewChiefV4/QueuedMessage.cs
+++ b/CrewChiefV4/QueuedMessage.cs
@@ -220,14 +220,14 @@ namespace CrewChiefV4
         }
 
         // called when we repeat this message - clears all the validation and sets the type to voice-command
-        public void prepareToBeRepeated(int newMessageId)
+        public void prepareToBeRepeated()
         {
             if (metadata == null)
             {
                 metadata = new SoundMetadata();
             }
             messageName = "REPEAT_" + messageName;
-            metadata.messageId = newMessageId;
+            metadata.messageId = getMessageId();
             metadata.priority = 5;
             metadata.type = SoundType.VOICE_COMMAND_RESPONSE;
             dueTime = 0;

--- a/CrewChiefV4/SpeechRecogniser.cs
+++ b/CrewChiefV4/SpeechRecogniser.cs
@@ -449,7 +449,6 @@ namespace CrewChiefV4
             {
                 return;
             }
-            return;
             
             if (waveIn != null)
             {


### PR DESCRIPTION
blimey this escalated quickly.

I wanted to force events to set a 'message expiry' time, so stale messages don't get played. Originally this was to allow the 'hold channel open' behaviour in the spotter to prevent the Chief inserting a cheeky message in between 'hold your line...' calls. This exposed a weakness in the current code where a message can be delayed (by this new change, or by existing hard-parts stuff, etc) but the message has no expiry.

Every message should be required to explicitly set its expiry time (or deliberate be un-expiring). So I unfucked the QueuedMessage ctors, and this is the result. Untested (I'll to it later).