### PR TITLE
Ignore rear tyres in fwd

### DIFF
--- a/CrewChiefV4/Events/TyreMonitor.cs
+++ b/CrewChiefV4/Events/TyreMonitor.cs
@@ -190,8 +190,6 @@ namespace CrewChiefV4.Events
         private int lastBrakeTempCheckLap = 0;
         private int lapsBetweenTyreTempChecks = 1;
         private int lastTyreTempCheckLap = 0;
-        private Boolean tyreTempsAreBouncing = false;
-        private Boolean brakeTempsAreBouncing = false;
         private List<List<MessageFragment>> tyreTempMessagesPlayed = new List<List<MessageFragment>>();
         private List<List<MessageFragment>> brakeTempMessagesPlayed = new List<List<MessageFragment>>();
         
@@ -346,8 +344,6 @@ namespace CrewChiefV4.Events
             lastBrakeTempCheckLap = 0;
             lapsBetweenTyreTempChecks = 1;
             lastTyreTempCheckLap = 0;
-            tyreTempsAreBouncing = false;
-            brakeTempsAreBouncing = false;
             lastTyreConditionMessage = null;
             peakBrakeTempForLap = 0;
             timeLeftFrontIsLockedForLap = 0;

--- a/CrewChiefV4/Events/TyreMonitor.cs
+++ b/CrewChiefV4/Events/TyreMonitor.cs
@@ -162,7 +162,7 @@ namespace CrewChiefV4.Events
         // check at start of which sector (1=s/f line)
         private int checkBrakesAtSector = 3;
         private float lastBrakeTempCheckSessionTime = -1.0f;
-        private const float SecondsBetweenBrakeTempCheck = 120.0f;
+        private float secondsBetweenBrakeTempCheck = 120.0f;
 
         private Boolean reportedTyreWearForCurrentPitEntry;
 
@@ -364,7 +364,7 @@ namespace CrewChiefV4.Events
             warnedOnLockingForLap = false;
             warnedOnWheelspinForLap = false;
             nextLockingAndSpinningCheck = DateTime.MinValue;
-
+            secondsBetweenBrakeTempCheck = 120.0f;
             leftFrontTyreTemp = 0;
             rightFrontTyreTemp = 0;
             leftRearTyreTemp = 0;
@@ -735,19 +735,21 @@ namespace CrewChiefV4.Events
                 currentGameState.SessionData.IsNewSector && currentGameState.SessionData.SectorNumber == thisLapTyreTempReportSector)
             {
                 reportCurrentTyreTempStatus(false);
+                lastTyreTempCheckLap = completedLaps;
             }
 
             if (!currentGameState.SessionData.LeaderHasFinishedRace &&
                     ((checkBrakesAtSector == 1 && currentGameState.SessionData.IsNewLap && completedLaps >= lastBrakeTempCheckLap + lapsBetweenBrakeTempChecks) ||
                     ((currentGameState.SessionData.IsNewSector && currentGameState.SessionData.SectorNumber == checkBrakesAtSector && completedLaps >= lastBrakeTempCheckLap + lapsBetweenBrakeTempChecks))) &&
-                    (lastBrakeTempCheckSessionTime == -1.0f || ((currentGameState.SessionData.SessionRunningTime - lastBrakeTempCheckSessionTime) > TyreMonitor.SecondsBetweenBrakeTempCheck)))
+                    (lastBrakeTempCheckSessionTime == -1.0f || ((currentGameState.SessionData.SessionRunningTime - lastBrakeTempCheckSessionTime) > secondsBetweenBrakeTempCheck)))
             {
                 if (!currentGameState.PitData.InPitlane && currentGameState.SessionData.CompletedLaps >= lapsIntoSessionBeforeTempMessage)
                 {
                     if (enableBrakeTempWarnings && !GlobalBehaviourSettings.useOvalLogic)
                     {
-                        lastBrakeTempCheckSessionTime = currentGameState.SessionData.SessionRunningTime;
                         reportBrakeTempStatus(false, true);
+                        lastBrakeTempCheckSessionTime = currentGameState.SessionData.SessionRunningTime;
+                        lastBrakeTempCheckLap = completedLaps;
                     }
                 }
                 peakBrakeTempForLap = 0;
@@ -973,6 +975,7 @@ namespace CrewChiefV4.Events
                     if (isBouncing(brakeTempMessagesPlayed, 3))
                     {
                         lapsBetweenBrakeTempChecks++;
+                        secondsBetweenBrakeTempCheck += 120f;
                         Console.WriteLine("This brake temp message has already been played recently, increasing check interval");
                     }
                 }

--- a/CrewChiefV4/Events/TyreMonitor.cs
+++ b/CrewChiefV4/Events/TyreMonitor.cs
@@ -865,9 +865,9 @@ namespace CrewChiefV4.Events
         public void reportCurrentTyreTempStatus(Boolean playImmediately)
         {
             List<MessageFragment> messageContents = new List<MessageFragment>();
-            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COLD), TyreTemp.COLD, messageContents);
-            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.HOT), TyreTemp.HOT, messageContents);
-            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COOKING), TyreTemp.COOKING, messageContents);
+            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COLD), TyreTemp.COLD, messageContents, CrewChief.currentGameState.carClass);
+            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.HOT), TyreTemp.HOT, messageContents, CrewChief.currentGameState.carClass);
+            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COOKING), TyreTemp.COOKING, messageContents, CrewChief.currentGameState.carClass);
 
             if (messageContents.Count == 0)
             {
@@ -898,25 +898,24 @@ namespace CrewChiefV4.Events
 
         public void reportBrakeTempStatus(Boolean playImmediately, Boolean peak)
         {
-            CarData.CarClassEnum carClassEnum = CrewChief.currentGameState.carClass.carClassEnum;
             List<MessageFragment> messageContents = new List<MessageFragment>();
             if (peak)
             {
                 if (!GlobalBehaviourSettings.useOvalLogic)
                 {
-                    addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, carClassEnum);
+                    addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, CrewChief.currentGameState.carClass);
                 }
-                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, carClassEnum);
-                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, carClassEnum);
+                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, CrewChief.currentGameState.carClass);
+                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, CrewChief.currentGameState.carClass);
             }
             else
             {
                 if (!GlobalBehaviourSettings.useOvalLogic)
                 {
-                    addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, carClassEnum);
+                    addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, CrewChief.currentGameState.carClass);
                 }
-                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, carClassEnum);
-                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, carClassEnum);
+                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, CrewChief.currentGameState.carClass);
+                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, CrewChief.currentGameState.carClass);
             }
             if (messageContents.Count == 0)
             {
@@ -1288,7 +1287,7 @@ namespace CrewChiefV4.Events
             }
         }
 
-        private void addTyreTempWarningMessages(CornerData.Corners corners, TyreTemp tyreTemp, List<MessageFragment> messageContents)
+        private void addTyreTempWarningMessages(CornerData.Corners corners, TyreTemp tyreTemp, List<MessageFragment> messageContents, CarData.CarClass carClass)
         {
             switch (corners)
             {
@@ -1587,7 +1586,7 @@ namespace CrewChiefV4.Events
             }
         }
 
-        private void addBrakeTempWarningMessages(CornerData.Corners corners, BrakeTemp brakeTemp, List<MessageFragment> messageContents, CarData.CarClassEnum carClassEnum)
+        private void addBrakeTempWarningMessages(CornerData.Corners corners, BrakeTemp brakeTemp, List<MessageFragment> messageContents, CarData.CarClass carClass)
         {
             switch (corners)
             {
@@ -1595,7 +1594,7 @@ namespace CrewChiefV4.Events
                     switch (brakeTemp)
                     {
                         case BrakeTemp.COLD:
-                            if (!ignoreColdBrakesForClasses.Contains(carClassEnum))
+                            if (!ignoreColdBrakesForClasses.Contains(carClass.carClassEnum))
                             {
                                 messageContents.Add(MessageFragment.Text(folderColdBrakesAllRound));
                             }
@@ -1614,7 +1613,7 @@ namespace CrewChiefV4.Events
                     switch (brakeTemp)
                     {
                         case BrakeTemp.COLD:
-                            if (!ignoreColdBrakesForClasses.Contains(carClassEnum))
+                            if (!ignoreColdBrakesForClasses.Contains(carClass.carClassEnum))
                             {
                                 messageContents.Add(MessageFragment.Text(folderColdFrontBrakes));
                             }
@@ -1630,22 +1629,26 @@ namespace CrewChiefV4.Events
                     }
                     break;
                 case CornerData.Corners.REARS:
-                    switch (brakeTemp)
+                    // for FWD cars we don't care about rear brake temps
+                    if (!carClass.allMembersAreFWD)
                     {
-                        case BrakeTemp.COLD:
-                            if (!ignoreColdBrakesForClasses.Contains(carClassEnum))
-                            {
-                                messageContents.Add(MessageFragment.Text(folderColdRearBrakes));
-                            }
-                            break;
-                        case BrakeTemp.HOT:
-                            messageContents.Add(MessageFragment.Text(folderHotRearBrakes));
-                            break;
-                        case BrakeTemp.COOKING:
-                            messageContents.Add(MessageFragment.Text(folderCookingRearBrakes));
-                            break;
-                        default:
-                            break;
+                        switch (brakeTemp)
+                        {
+                            case BrakeTemp.COLD:
+                                if (!ignoreColdBrakesForClasses.Contains(carClass.carClassEnum))
+                                {
+                                    messageContents.Add(MessageFragment.Text(folderColdRearBrakes));
+                                }
+                                break;
+                            case BrakeTemp.HOT:
+                                messageContents.Add(MessageFragment.Text(folderHotRearBrakes));
+                                break;
+                            case BrakeTemp.COOKING:
+                                messageContents.Add(MessageFragment.Text(folderCookingRearBrakes));
+                                break;
+                            default:
+                                break;
+                        }
                     }
                     break;
                 default:

--- a/CrewChiefV4/Events/TyreMonitor.cs
+++ b/CrewChiefV4/Events/TyreMonitor.cs
@@ -864,10 +864,13 @@ namespace CrewChiefV4.Events
 
         public void reportCurrentTyreTempStatus(Boolean playImmediately)
         {
+            // for FWD classes we don't care about rear tyres
+            Boolean includeRears = playImmediately || !CrewChief.currentGameState.carClass.allMembersAreFWD;
+
             List<MessageFragment> messageContents = new List<MessageFragment>();
-            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COLD), TyreTemp.COLD, messageContents, CrewChief.currentGameState.carClass);
-            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.HOT), TyreTemp.HOT, messageContents, CrewChief.currentGameState.carClass);
-            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COOKING), TyreTemp.COOKING, messageContents, CrewChief.currentGameState.carClass);
+            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COLD), TyreTemp.COLD, messageContents, includeRears);
+            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.HOT), TyreTemp.HOT, messageContents, includeRears);
+            addTyreTempWarningMessages(currentTyreTempStatus.getCornersForStatus(TyreTemp.COOKING), TyreTemp.COOKING, messageContents, includeRears);
 
             if (messageContents.Count == 0)
             {
@@ -898,24 +901,26 @@ namespace CrewChiefV4.Events
 
         public void reportBrakeTempStatus(Boolean playImmediately, Boolean peak)
         {
+            // for FWD classes we don't care about rear tyres
+            Boolean includeRears = playImmediately || !CrewChief.currentGameState.carClass.allMembersAreFWD;
             List<MessageFragment> messageContents = new List<MessageFragment>();
             if (peak)
             {
                 if (!GlobalBehaviourSettings.useOvalLogic)
                 {
-                    addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, CrewChief.currentGameState.carClass);
+                    addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, includeRears);
                 }
-                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, CrewChief.currentGameState.carClass);
-                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, CrewChief.currentGameState.carClass);
+                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, includeRears);
+                addBrakeTempWarningMessages(peakBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, includeRears);
             }
             else
             {
                 if (!GlobalBehaviourSettings.useOvalLogic)
                 {
-                    addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, CrewChief.currentGameState.carClass);
+                    addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COLD), BrakeTemp.COLD, messageContents, includeRears);
                 }
-                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, CrewChief.currentGameState.carClass);
-                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, CrewChief.currentGameState.carClass);
+                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.HOT), BrakeTemp.HOT, messageContents, includeRears);
+                addBrakeTempWarningMessages(currentBrakeTempStatus.getCornersForStatus(BrakeTemp.COOKING), BrakeTemp.COOKING, messageContents, includeRears);
             }
             if (messageContents.Count == 0)
             {
@@ -1287,7 +1292,7 @@ namespace CrewChiefV4.Events
             }
         }
 
-        private void addTyreTempWarningMessages(CornerData.Corners corners, TyreTemp tyreTemp, List<MessageFragment> messageContents, CarData.CarClass carClass)
+        private void addTyreTempWarningMessages(CornerData.Corners corners, TyreTemp tyreTemp, List<MessageFragment> messageContents, Boolean includeRears)
         {
             switch (corners)
             {
@@ -1324,19 +1329,22 @@ namespace CrewChiefV4.Events
                     }
                     break;
                 case CornerData.Corners.REARS:
-                    switch (tyreTemp)
+                    if (includeRears)
                     {
-                        case TyreTemp.COLD:
-                            messageContents.Add(MessageFragment.Text(folderColdRearTyres));
-                            break;
-                        case TyreTemp.HOT:
-                            messageContents.Add(MessageFragment.Text(folderHotRearTyres));
-                            break;
-                        case TyreTemp.COOKING:
-                            messageContents.Add(MessageFragment.Text(folderCookingRearTyres));
-                            break;
-                        default:
-                            break;
+                        switch (tyreTemp)
+                        {
+                            case TyreTemp.COLD:
+                                messageContents.Add(MessageFragment.Text(folderColdRearTyres));
+                                break;
+                            case TyreTemp.HOT:
+                                messageContents.Add(MessageFragment.Text(folderHotRearTyres));
+                                break;
+                            case TyreTemp.COOKING:
+                                messageContents.Add(MessageFragment.Text(folderCookingRearTyres));
+                                break;
+                            default:
+                                break;
+                        }
                     }
                     break;
                 case CornerData.Corners.LEFTS:
@@ -1404,32 +1412,38 @@ namespace CrewChiefV4.Events
                     }
                     break;
                 case CornerData.Corners.REAR_LEFT:
-                    if (!GlobalBehaviourSettings.useOvalLogic)
+                    if (includeRears)
                     {
-                        switch (tyreTemp)
+                        if (!GlobalBehaviourSettings.useOvalLogic)
                         {
-                            case TyreTemp.HOT:
-                                messageContents.Add(MessageFragment.Text(folderHotLeftRearTyre));
-                                break;
-                            case TyreTemp.COOKING:
-                                messageContents.Add(MessageFragment.Text(folderCookingLeftRearTyre));
-                                break;
-                            default:
-                                break;
+                            switch (tyreTemp)
+                            {
+                                case TyreTemp.HOT:
+                                    messageContents.Add(MessageFragment.Text(folderHotLeftRearTyre));
+                                    break;
+                                case TyreTemp.COOKING:
+                                    messageContents.Add(MessageFragment.Text(folderCookingLeftRearTyre));
+                                    break;
+                                default:
+                                    break;
+                            }
                         }
                     }
                     break;
                 case CornerData.Corners.REAR_RIGHT:
-                    switch (tyreTemp)
+                    if (includeRears)
                     {
-                        case TyreTemp.HOT:
-                            messageContents.Add(MessageFragment.Text(folderHotRightRearTyre));
-                            break;
-                        case TyreTemp.COOKING:
-                            messageContents.Add(MessageFragment.Text(folderCookingRightRearTyre));
-                            break;
-                        default:
-                            break;
+                        switch (tyreTemp)
+                        {
+                            case TyreTemp.HOT:
+                                messageContents.Add(MessageFragment.Text(folderHotRightRearTyre));
+                                break;
+                            case TyreTemp.COOKING:
+                                messageContents.Add(MessageFragment.Text(folderCookingRightRearTyre));
+                                break;
+                            default:
+                                break;
+                        }
                     }
                     break;
             }
@@ -1586,7 +1600,7 @@ namespace CrewChiefV4.Events
             }
         }
 
-        private void addBrakeTempWarningMessages(CornerData.Corners corners, BrakeTemp brakeTemp, List<MessageFragment> messageContents, CarData.CarClass carClass)
+        private void addBrakeTempWarningMessages(CornerData.Corners corners, BrakeTemp brakeTemp, List<MessageFragment> messageContents, Boolean includeRears)
         {
             switch (corners)
             {
@@ -1594,7 +1608,7 @@ namespace CrewChiefV4.Events
                     switch (brakeTemp)
                     {
                         case BrakeTemp.COLD:
-                            if (!ignoreColdBrakesForClasses.Contains(carClass.carClassEnum))
+                            if (!ignoreColdBrakesForClasses.Contains(CrewChief.currentGameState.carClass.carClassEnum))
                             {
                                 messageContents.Add(MessageFragment.Text(folderColdBrakesAllRound));
                             }
@@ -1613,7 +1627,7 @@ namespace CrewChiefV4.Events
                     switch (brakeTemp)
                     {
                         case BrakeTemp.COLD:
-                            if (!ignoreColdBrakesForClasses.Contains(carClass.carClassEnum))
+                            if (!ignoreColdBrakesForClasses.Contains(CrewChief.currentGameState.carClass.carClassEnum))
                             {
                                 messageContents.Add(MessageFragment.Text(folderColdFrontBrakes));
                             }
@@ -1629,13 +1643,12 @@ namespace CrewChiefV4.Events
                     }
                     break;
                 case CornerData.Corners.REARS:
-                    // for FWD cars we don't care about rear brake temps
-                    if (!carClass.allMembersAreFWD)
+                    if (includeRears)
                     {
                         switch (brakeTemp)
                         {
                             case BrakeTemp.COLD:
-                                if (!ignoreColdBrakesForClasses.Contains(carClass.carClassEnum))
+                                if (!ignoreColdBrakesForClasses.Contains(CrewChief.currentGameState.carClass.carClassEnum))
                                 {
                                     messageContents.Add(MessageFragment.Text(folderColdRearBrakes));
                                 }


### PR DESCRIPTION
for classes where all cars are FWD, don't allow tyre and brake temp warnings to include rear tyres / brakes, if these messages are triggered automatically